### PR TITLE
docs: バックエンド開発タスクドキュメントを追加

### DIFF
--- a/backend/docs/開発タスク.md
+++ b/backend/docs/開発タスク.md
@@ -1,0 +1,185 @@
+# バックエンド 開発スケジュール
+
+> **担当:** バックエンド 1人（Python / FastAPI / PostgreSQL）
+> **進め方:** フェーズ順に進む。Phase 0 の意思決定が終わらないと後続フェーズのスキーマが確定しないため、最優先で潰す。
+
+---
+
+## 凡例
+
+| マーク | 優先度 | 意味 |
+|--------|--------|------|
+| 🔴 | HIGH | ブロッカー / 実装開始に必須 |
+| 🟡 | MEDIUM | コア機能、早めに着手 |
+| 🟢 | LOW | ブロッカー待ち or ハッカソンスコープ外候補 |
+
+---
+
+## Phase 0: 意思決定
+
+> 実装ブロッカーになる未決定事項を先に潰す。
+> 根拠は `データモデル草案.md § 仕様確認が必要な事項` を参照。
+
+### 認証 / ユーザー
+
+- [ ] 🔴 **E-1** 認証方式を確定する（JWT / OAuth2）— JWTで進めるなら即決定
+- [ ] 🔴 **D-1** `UserSettings` / `NotificationSettings` の初期作成タイミングを確定する（register 時一括 / 遅延作成）
+- [ ] 🟢 **E-2** パスワードリセット機能をハッカソンスコープに含めるか決める
+
+### タグ
+
+- [ ] 🔴 **A-1** タグのスコープを確定する（グローバル全ユーザー共通 / per-user）— DBスキーマに直結
+- [ ] 🔴 **A-2** タグ作成権限を確定する（ユーザーが自由作成 / 事前定義のみ）— seed 要否に影響
+
+### Schedule / Template
+
+- [ ] 🔴 **B-1** `travel_mode` ENUM 値を確定する（walking / cycling / transit / driving で十分か）
+- [ ] 🟡 **B-3** `Schedule.travel_mode` を nullable にするか確定する（目的地なし予定への対応）
+- [ ] 🟡 **B-4** 終日フラグ（`is_all_day`）の要否を確定する（カレンダーUI連携）
+- [ ] 🟡 **B-5** ソフトデリート（`deleted_at`）の要否を確定する
+- [ ] 🟢 **B-6** 繰り返し予定の対応範囲を決める（ハッカソンスコープ外候補）
+
+### 通知
+
+- [ ] 🟢 **C-1** リマインダー複数設定の対応範囲を決める（現在は `reminder_minutes_before` 1つ）
+
+### 外部API
+
+- [ ] 🟡 **Routes** 経路 API を選定する（Google Directions API / Yahoo! 乗換 API 等）— Phase 7 のブロッカー
+- [ ] 🟢 **Suggestions** 提案ロジックのルールを定義する（例: 雨 × タグ=デート → 折り畳み傘）— Phase 8 のブロッカー
+
+---
+
+## Phase 1: 基盤構築
+
+> FastAPI / DB / マイグレーション / 共通ミドルウェアのセットアップ
+
+- [ ] 🔴 FastAPI プロジェクトのディレクトリ構成を決めて作成する
+- [ ] 🔴 依存パッケージを定義する（`pyproject.toml` / `requirements.txt`）
+- [ ] 🔴 環境変数管理を実装する（`.env` / `pydantic-settings`）
+- [ ] 🔴 PostgreSQL 接続設定を実装する（SQLAlchemy async + asyncpg）
+- [ ] 🔴 Alembic マイグレーションの初期設定をする
+- [ ] 🟡 Docker / docker-compose 設定をする（DB + API）
+- [ ] 🟡 共通エラーレスポンス形式を実装する（`API詳細設計.md § エラーレスポンス` 準拠）
+- [ ] 🟡 CORS ミドルウェアを設定する
+- [ ] 🟡 ヘルスチェックエンドポイントを実装する（`GET /healthz`）
+
+---
+
+## Phase 2: 認証 (Auth)
+
+> Phase 0 の E-1（認証方式）確定後に着手
+
+- [ ] 🔴 `User` モデルを作成しマイグレーションを実行する
+- [ ] 🔴 パスワードハッシュを実装する（bcrypt）
+- [ ] 🔴 JWT アクセストークン生成・検証ロジックを実装する
+- [ ] 🔴 認証依存注入を実装する（`get_current_user`）
+- [ ] 🔴 `POST /auth/register` を実装する
+- [ ] 🔴 `POST /auth/login` を実装する
+- [ ] 🟡 リフレッシュトークン管理を実装する
+- [ ] 🟡 `POST /auth/refresh` を実装する
+- [ ] 🟡 `POST /auth/logout` を実装する
+
+---
+
+## Phase 3: ユーザー (Users)
+
+> Phase 0 の D-1（UserSettings 初期作成タイミング）確定後に着手
+
+- [ ] 🔴 `UserSettings` モデルを作成しマイグレーションを実行する
+- [ ] 🔴 `GET /users/me` を実装する
+- [ ] 🔴 `PUT /users/me` を実装する
+- [ ] 🔴 `GET /users/me/settings` を実装する
+- [ ] 🔴 `PUT /users/me/settings` を実装する
+
+---
+
+## Phase 4: コアAPI (Tags / Schedules / Templates)
+
+> Phase 0 の A-1・A-2・B-1（タグスコープ/作成権限、travel_mode ENUM）確定後に着手
+
+### Tags
+
+- [ ] 🔴 `Tag` モデルを作成しマイグレーションを実行する
+- [ ] 🔴 `GET /tags` を実装する（タグ一覧取得）
+- [ ] 🟡 `POST /tags` を実装する（タグ作成 — A-2 の決定に依存）
+
+### Schedules
+
+- [ ] 🔴 `Schedule` / `ScheduleTag` モデルを作成しマイグレーションを実行する
+- [ ] 🔴 `GET /schedules` を実装する（クエリパラメータ: `start_date` / `end_date`）
+- [ ] 🔴 `POST /schedules` を実装する
+- [ ] 🔴 `GET /schedules/{id}` を実装する
+- [ ] 🔴 `PUT /schedules/{id}` を実装する
+- [ ] 🔴 `DELETE /schedules/{id}` を実装する
+
+### Templates
+
+- [ ] 🟡 `Template` / `TemplateTag` モデルを作成しマイグレーションを実行する
+- [ ] 🟡 `GET /templates` を実装する
+- [ ] 🟡 `POST /templates` を実装する
+- [ ] 🟡 `GET /templates/{id}` を実装する
+- [ ] 🟡 `PUT /templates/{id}` を実装する
+- [ ] 🟡 `DELETE /templates/{id}` を実装する
+- [ ] 🟡 `POST /templates/{id}/apply` を実装する（テンプレートからスケジュールをコピー作成）
+
+---
+
+## Phase 5: 外部API連携 — 天気 (Weather)
+
+> WeatherAPI.com を使用（`API詳細設計.md § Weather` 参照）
+
+- [ ] 🟡 WeatherAPI.com クライアントを実装する
+- [ ] 🟡 API キーを環境変数で管理する
+- [ ] 🟡 `GET /weather` を実装する（指定日時・場所の天気取得）
+- [ ] 🟡 `GET /weather/forecast` を実装する（3日間予報取得）
+
+---
+
+## Phase 6: 通知設定 (Notifications)
+
+> Phase 0 の D-1（NotificationSettings 初期作成タイミング）確定後に着手
+
+- [ ] 🟡 `NotificationSettings` モデルを作成しマイグレーションを実行する
+- [ ] 🟡 `DeviceToken` モデルを作成しマイグレーションを実行する
+- [ ] 🟡 `GET /notifications/settings` を実装する
+- [ ] 🟡 `PUT /notifications/settings` を実装する
+- [ ] 🟡 `POST /notifications/tokens` を実装する（デバイストークン登録）
+- [ ] 🟡 `DELETE /notifications/tokens/{token}` を実装する
+
+---
+
+## Phase 7: 経路API (Routes) ← ブロッカー待ち
+
+> Phase 0 の Routes（経路 API 選定）が完了するまで着手不可
+> 詳細は `API詳細設計.md § Routes` 参照
+
+- [ ] 🟢 外部経路 API クライアントを実装する（API 選定後）
+- [ ] 🟢 `POST /routes/search` を実装する
+- [ ] 🟢 `POST /routes/departure-time` を実装する
+
+---
+
+## Phase 8: 提案 (Suggestions) ← ブロッカー待ち
+
+> Phase 0 の Suggestions（提案ロジック ルール定義）が完了するまで着手不可
+> 詳細は `API詳細設計.md § Suggestions` 参照
+
+- [ ] 🟢 提案ルールを定義してロジックを実装する
+- [ ] 🟢 `GET /suggestions` を実装する
+
+---
+
+## Phase 9: テスト・品質
+
+> Phase 4 完了後から並行して進めることを推奨
+
+- [ ] 🟡 pytest セットアップをする（テスト用 DB 設定含む）
+- [ ] 🟡 リンター / フォーマッターを設定する（ruff / black）
+- [ ] 🟡 Auth API のテストを書く
+- [ ] 🟡 Users API のテストを書く
+- [ ] 🟡 Schedules API のテストを書く
+- [ ] 🟡 Tags / Templates API のテストを書く
+- [ ] 🟢 Weather API のテストを書く（外部 API モックを使用）
+- [ ] 🟢 テストカバレッジを計測する（目標: コアAPI 80% 以上）
+- [ ] 🟢 CI（GitHub Actions）を設定する（lint + test の自動実行）


### PR DESCRIPTION
## Summary

- `backend/docs/開発タスク.md` を新規作成
- バックエンド実装の意思決定事項・フェーズ別タスク・ブロッカーを一覧化
- Phase 0（意思決定）が後続フェーズのスキーマ確定に必須であることを明記
- 認証 / ユーザー・タグ・天気・位置情報・Routes・通知など全機能のタスクを優先度付きで整理

## Test plan

- [x] ドキュメントの内容が `データモデル草案.md`・`API詳細設計.md`・`api仕様.md` と整合していること
- [x] Phase 0 の意思決定事項が網羅されていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)