### PR TITLE
docs: Phase 0 の意思決定を全ドキュメントに反映する

### DIFF
--- a/backend/docs/データモデル草案.md
+++ b/backend/docs/データモデル草案.md
@@ -96,8 +96,9 @@
 | destination_address | VARCHAR(255) | nullable |
 | destination_lat | DECIMAL(9,6) | nullable |
 | destination_lon | DECIMAL(9,6) | nullable |
-| travel_mode | ENUM | walking / cycling / transit / driving |
+| travel_mode | ENUM | nullable, walking / cycling / transit / driving |
 | memo | TEXT | 準備事項 nullable |
+| recurrence_rule | VARCHAR(500) | nullable, 将来の繰り返し予定用 (RRULE形式) |
 | created_at | TIMESTAMP | |
 | updated_at | TIMESTAMP | |
 
@@ -221,6 +222,7 @@ erDiagram
         decimal destination_lon
         enum travel_mode
         text memo
+        varchar recurrence_rule
         timestamp created_at
         timestamp updated_at
     }
@@ -252,48 +254,59 @@ erDiagram
 | DeviceToken | **別テーブル** | 1ユーザー複数端末を想定 |
 | UserSettings | **User と別テーブル（1:1）** | プロフィールと設定を分離し、取得・更新を独立して行えるようにする |
 | 天気・経路データ | **DBに保存しない** | BFF として外部API（WeatherAPI.com 等）をリクエスト時に都度呼び出す |
+| 認証方式 | **JWT のみ** | アクセストークン + リフレッシュトークン。シンプル、ハッカソン向き |
+| UserSettings / NotificationSettings 初期化 | **register 時一括作成** | デフォルト値をそれぞれ設計し、同一トランザクションで生成。null チェック不要でシンプル |
+| タグのスコープ | **グローバル（全ユーザー共通）** | `Tag.name UNIQUE` を維持 |
+| タグ作成権限 | **事前定義のみ（seed データ投入）** | `POST /tags` は実装しない |
+| `Schedule.travel_mode` の nullable | **nullable** | 目的地なし予定（自宅リモート等）に対応 |
+| 終日フラグ（`is_all_day`）| **追加しない** | ハッカソンスコープ外 |
+| ソフトデリート | **物理削除** | `deleted_at` カラム追加なし。実装をシンプルに保つ |
+| パスワードリセット | **スコープ外** | `PasswordResetToken` テーブル不要 |
+| 繰り返し予定 | **`recurrence_rule VARCHAR(500)` を nullable で追加** | 現時点は非対応。将来 RRULE 形式で使用できるよう拡張可能な設計にする |
+| リマインダー設定 | **1つのみ（`reminder_minutes_before`）** | 現在は INT 1つ。将来の複数設定拡張を意識したコード設計にする |
+| 経路 API | **OTP2（検証中）** | Phase 7 で詳細設計。現在選定中のためブロッカー状態 |
+| Suggestions（提案ロジック）| **スコープ外** | Phase 8 は実装しない |
 
 ---
 
-## 仕様確認が必要な事項
+## 仕様確認が必要な事項（✅ 全項目確定済み）
 
-実装前にチームで確認・決定が必要な未決定事項。
-各項目に「現在の草案での扱い」「代替案・影響」を記載。
+> Phase 0 の意思決定フェーズで全項目が確定。確定内容は「確定した設計判断」テーブルを参照。
 
 ### A. Tag（タグ）関連
 
-| # | 確認事項 | 現在の草案 | 代替案 / 影響 |
-|---|---------|-----------|--------------|
-| A-1 | **タグのスコープ** — グローバル（全ユーザー共通）か、ユーザーごと個別か | グローバル（`Tag.name UNIQUE`） | per-user: `Tag` に `user_id` FK を追加。同名タグをユーザーごとに持てる |
-| A-2 | **タグの作成権限** — ユーザーが自由にタグを作れるか、事前定義のみか | 自由作成と仮定 | 事前定義のみなら初期データ投入（seed）が必要。管理者機能も要検討 |
+| # | 確認事項 | 状態 | 決定 |
+|---|---------|------|------|
+| A-1 | **タグのスコープ** | ✅ 確定 | グローバル（全ユーザー共通）。`Tag.name UNIQUE` を維持 |
+| A-2 | **タグの作成権限** | ✅ 確定 | 事前定義のみ（seed データ投入）。`POST /tags` は実装しない |
 
 ### B. Schedule / Template 関連
 
-| # | 確認事項 | 現在の草案 | 代替案 / 影響 |
-|---|---------|-----------|--------------|
-| B-1 | **travel_mode の ENUM 値** — walking / cycling / transit / driving で十分か | 4値 | cycling 不要ならシンプル化。「移動なし（none）」が必要なら追加 |
-| B-2 | **Schedule.end_at の nullable** — 終日予定や時刻未定に対応するか | nullable | NOT NULL にするとUI側で必須入力になる |
-| B-3 | **Schedule.travel_mode の nullable** — 目的地なし予定（自宅リモート等）に対応するか | nullable 明示なし（未定） | NOT NULL にすると移動手段が必須入力になる |
-| B-4 | **終日フラグ（is_all_day）の必要性** — カレンダー機能で終日イベントを扱うか | なし | 追加する場合 Schedule に `is_all_day BOOLEAN` カラムを追加 |
-| B-5 | **ソフトデリートの必要性** — 削除時に物理削除か、論理削除（deleted_at）か | 物理削除と仮定 | 論理削除なら `deleted_at TIMESTAMP nullable` を Schedule / Template に追加 |
-| B-6 | **繰り返し予定の対応** — 毎週月曜など定期的な予定をサポートするか | 非対応 | 対応するなら `recurrence_rule` カラムまたは別テーブルが必要 |
+| # | 確認事項 | 状態 | 決定 |
+|---|---------|------|------|
+| B-1 | **travel_mode の ENUM 値** | ✅ 確定 | walking / cycling / transit / driving の 4 値 |
+| B-2 | **Schedule.end_at の nullable** | ✅ 確定 | nullable（変更なし） |
+| B-3 | **Schedule.travel_mode の nullable** | ✅ 確定 | nullable。目的地なし予定（自宅リモート等）に対応 |
+| B-4 | **終日フラグ（is_all_day）の必要性** | ✅ 確定 | 追加しない。ハッカソンスコープ外 |
+| B-5 | **ソフトデリートの必要性** | ✅ 確定 | 物理削除。`deleted_at` カラム追加なし |
+| B-6 | **繰り返し予定の対応** | ✅ 確定 | 現時点は非対応。`recurrence_rule VARCHAR(500)` を nullable で追加し将来の拡張に備える |
 
 ### C. 通知関連
 
-| # | 確認事項 | 現在の草案 | 代替案 / 影響 |
-|---|---------|-----------|--------------|
-| C-1 | **リマインダーの複数設定** — 「30分前」と「1時間前」など複数タイミングを設定できるか | `reminder_minutes_before` の INT 1つのみ | 複数対応する場合は `NotificationSettings` を 1:N にするか JSON 型カラムが必要 |
-| C-2 | **DeviceToken の有効期限管理** — 期限切れ・無効トークンをどう扱うか | `expired_at` 等のフィールドなし | push 失敗時に削除するだけでよければ追加不要。定期 purge するなら `last_used_at` を追加 |
+| # | 確認事項 | 状態 | 決定 |
+|---|---------|------|------|
+| C-1 | **リマインダーの複数設定** | ✅ 確定 | 現時点は 1 つのみ（`reminder_minutes_before`）。将来拡張を意識したコード設計にする |
+| C-2 | **DeviceToken の有効期限管理** | ✅ 確定 | push 失敗時に削除するのみ。`expired_at` 等は追加しない |
 
 ### D. UserSettings / 初期化フロー関連
 
-| # | 確認事項 | 現在の草案 | 代替案 / 影響 |
-|---|---------|-----------|--------------|
-| D-1 | **UserSettings / NotificationSettings の初期作成タイミング** — ユーザー登録時に自動作成するか、初回アクセス時に遅延作成するか | 未定 | 登録時に一括作成: シンプルだがデフォルト値の設計が必要。遅延作成: API側で null チェックが必要 |
+| # | 確認事項 | 状態 | 決定 |
+|---|---------|------|------|
+| D-1 | **UserSettings / NotificationSettings の初期作成タイミング** | ✅ 確定 | register 時に同一トランザクションで一括作成 |
 
 ### E. 認証関連
 
-| # | 確認事項 | 現在の草案 | 代替案 / 影響 |
-|---|---------|-----------|--------------|
-| E-1 | **認証方式** — JWT か OAuth2 か（api仕様.md § 2 で未決定） | 未決定（JWT推奨と記載） | OAuth2（Google連携）を選ぶ場合は `User` に `google_id` 等が必要 |
-| E-2 | **パスワードリセット機能の必要性** — ハッカソンスコープに含めるか | 非対応（データモデルなし） | 対応するなら `PasswordResetToken` テーブルを追加 |
+| # | 確認事項 | 状態 | 決定 |
+|---|---------|------|------|
+| E-1 | **認証方式** | ✅ 確定 | JWT のみ（アクセストークン + リフレッシュトークン） |
+| E-2 | **パスワードリセット機能の必要性** | ✅ 確定 | スコープ外。`PasswordResetToken` テーブル不要 |

--- a/backend/docs/開発タスク.md
+++ b/backend/docs/開発タスク.md
@@ -22,31 +22,31 @@
 
 ### 認証 / ユーザー
 
-- [ ] 🔴 **E-1** 認証方式を確定する（JWT / OAuth2）— JWTで進めるなら即決定
-- [ ] 🔴 **D-1** `UserSettings` / `NotificationSettings` の初期作成タイミングを確定する（register 時一括 / 遅延作成）
-- [ ] 🟢 **E-2** パスワードリセット機能をハッカソンスコープに含めるか決める
+- [x] 🔴 **E-1** 認証方式を確定する（JWT / OAuth2）— **JWT のみ**（アクセストークン + リフレッシュトークン）
+- [x] 🔴 **D-1** `UserSettings` / `NotificationSettings` の初期作成タイミングを確定する（register 時一括 / 遅延作成）— **register 時一括作成**
+- [x] 🟢 **E-2** パスワードリセット機能をハッカソンスコープに含めるか決める — **スコープ外**
 
 ### タグ
 
-- [ ] 🔴 **A-1** タグのスコープを確定する（グローバル全ユーザー共通 / per-user）— DBスキーマに直結
-- [ ] 🔴 **A-2** タグ作成権限を確定する（ユーザーが自由作成 / 事前定義のみ）— seed 要否に影響
+- [x] 🔴 **A-1** タグのスコープを確定する（グローバル全ユーザー共通 / per-user）— **グローバル**（`Tag.name UNIQUE` 維持）
+- [x] 🔴 **A-2** タグ作成権限を確定する（ユーザーが自由作成 / 事前定義のみ）— **事前定義のみ**（seed 投入、`POST /tags` は実装しない）
 
 ### Schedule / Template
 
-- [ ] 🔴 **B-1** `travel_mode` ENUM 値を確定する（walking / cycling / transit / driving で十分か）
-- [ ] 🟡 **B-3** `Schedule.travel_mode` を nullable にするか確定する（目的地なし予定への対応）
-- [ ] 🟡 **B-4** 終日フラグ（`is_all_day`）の要否を確定する（カレンダーUI連携）
-- [ ] 🟡 **B-5** ソフトデリート（`deleted_at`）の要否を確定する
-- [ ] 🟢 **B-6** 繰り返し予定の対応範囲を決める（ハッカソンスコープ外候補）
+- [x] 🔴 **B-1** `travel_mode` ENUM 値を確定する（walking / cycling / transit / driving で十分か）— **4 値で確定**
+- [x] 🟡 **B-3** `Schedule.travel_mode` を nullable にするか確定する（目的地なし予定への対応）— **nullable**
+- [x] 🟡 **B-4** 終日フラグ（`is_all_day`）の要否を確定する（カレンダーUI連携）— **不要**
+- [x] 🟡 **B-5** ソフトデリート（`deleted_at`）の要否を確定する — **不要（物理削除）**
+- [x] 🟢 **B-6** 繰り返し予定の対応範囲を決める（ハッカソンスコープ外候補）— **現時点は非対応。`recurrence_rule VARCHAR(500)` nullable を追加**
 
 ### 通知
 
-- [ ] 🟢 **C-1** リマインダー複数設定の対応範囲を決める（現在は `reminder_minutes_before` 1つ）
+- [x] 🟢 **C-1** リマインダー複数設定の対応範囲を決める（現在は `reminder_minutes_before` 1つ）— **現時点は 1 つのみ**
 
 ### 外部API
 
-- [ ] 🟡 **Routes** 経路 API を選定する（Google Directions API / Yahoo! 乗換 API 等）— Phase 7 のブロッカー
-- [ ] 🟢 **Suggestions** 提案ロジックのルールを定義する（例: 雨 × タグ=デート → 折り畳み傘）— Phase 8 のブロッカー
+- [x] 🟡 **Routes** 経路 API を選定する（Google Directions API / Yahoo! 乗換 API 等）— **OTP2**（検証中、Phase 7 で詳細設計）
+- [x] 🟢 **Suggestions** 提案ロジックのルールを定義する（例: 雨 × タグ=デート → 折り畳み傘）— **スコープ外**
 
 ---
 


### PR DESCRIPTION
## Summary

Phase 0（意思決定フェーズ）で確定した全 13 項目をドキュメントに反映します。

- **`データモデル草案.md`**
  - Schedule テーブルに `recurrence_rule VARCHAR(500) nullable` を追加（将来の繰り返し予定用）
  - `Schedule.travel_mode` を nullable 明示（目的地なし予定に対応）
  - ER図に `recurrence_rule` カラムを追記
  - 「確定した設計判断」テーブルに Phase 0 全決定事項（認証方式・タグスコープ・ソフトデリート等）を追記
  - 「仕様確認が必要な事項」を全項目 ✅ 確定済みに更新

- **`開発タスク.md`**
  - Phase 0 の全チェックボックス（E-1, D-1, E-2, A-1, A-2, B-1, B-3, B-4, B-5, B-6, C-1, Routes, Suggestions）を `[x]` にマークし、決定内容を各行に記載

## 確定した意思決定サマリー

| ID | 決定内容 |
|----|---------|
| E-1 | JWT のみ（アクセストークン + リフレッシュトークン） |
| D-1 | register 時一括作成 |
| E-2 | スコープ外 |
| A-1 | グローバル（Tag.name UNIQUE 維持） |
| A-2 | 事前定義のみ（POST /tags は実装しない） |
| B-1 | 4値確定（walking/cycling/transit/driving） |
| B-3 | nullable |
| B-4 | 不要 |
| B-5 | 物理削除 |
| B-6 | recurrence_rule nullable を追加、現時点は非対応 |
| C-1 | 1つのみ（reminder_minutes_before） |
| Routes | OTP2（検証中、Phase 7 で詳細設計） |
| Suggestions | スコープ外 |

## Test plan

- [ ] `データモデル草案.md` の「確定した設計判断」テーブルに全 13 決定事項が記載されていることを確認
- [ ] Schedule テーブルに `recurrence_rule` カラムが追記されていることを確認
- [ ] `開発タスク.md` の Phase 0 チェックボックスが全て `[x]` になっていることを確認
- [ ] Phase 1 以降の作業に入れる状態になっていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)