### PR TITLE
docs: POST /routes/search を削除し /routes/departure-time に itineraries[] を統合

### DIFF
--- a/backend/app/api/api仕様.md
+++ b/backend/app/api/api仕様.md
@@ -136,17 +136,11 @@ UIのオブジェクト指向設計（https://miro.com/app/board/uXjVG8RL25g=/ �
 
 | メソッド | エンドポイント | 概要 |
 |---------|--------------|------|
-| POST | `/routes/search` | 経路検索（出発地・目的地・移動手段） |
-| POST | `/routes/departure-time` | 到着時刻から出発時刻を逆算 |
-
-**`/routes/search` リクエスト想定項目:**
-- `origin` — 出発地（住所 or 座標）
-- `destination` — 目的地（住所 or 座標）
-- `mode` — 移動手段（`walking` / `cycling` / `transit` / `driving`）
-- `arrival_time` — 到着希望時刻（省略時は現在時刻出発）
+| POST | `/routes/departure-time` | 到着時刻から出発時刻を逆算・複数経路候補を取得 |
 
 **`/routes/departure-time` リクエスト想定項目:**
-- `destination`、`arrival_time`、`mode`、`preparation_minutes`（身支度時間）
+- `destination_lat`、`destination_lon`、`arrival_time`、`travel_mode`
+- 出発地（`home_lat` / `home_lon`）・身支度時間（`preparation_minutes`）はサーバーが `UserSettings` から自動取得
 
 ---
 


### PR DESCRIPTION
## Summary

- `POST /routes/search` エンドポイントをドキュメントから削除
- `POST /routes/departure-time` のレスポンスを単一 `itinerary` → `itineraries[]`（最大5件）に変更し、経路候補取得を統合
- `leave_home_at` / `start_preparation_at` の算出基準を `itineraries[0]` と明記
- `backend/app/api/api仕様.md` の Routes セクションも同期して更新

## 変更の背景

- フロントが「ルート選択 UI → 出発時刻確認」の流れで使うと OTP2 を2回叩くことになる問題を解消
- `departure-time` は `search` の結果に `leave_home_at` / `start_preparation_at` を付加しただけのため、1エンドポイントに統合することで OTP2 呼び出しを1回に削減

## Test plan

- [ ] `POST /routes/search` のセクションがドキュメントから消えていること
- [ ] `POST /routes/departure-time` のレスポンスに `itineraries[]` が定義されていること
- [ ] `leave_home_at` / `start_preparation_at` の基準が `itineraries[0]` であることが明記されていること
- [ ] `api仕様.md` の Routes テーブルに `/routes/search` の行が存在しないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)