### PR TITLE
docs: 残存ブロッカー調査結果をドキュメントに反映（OTP2確定・TemplateCategory値確定）

### DIFF
--- a/backend/docs/データモデル草案.md
+++ b/backend/docs/データモデル草案.md
@@ -30,6 +30,7 @@
 | home_lat | DECIMAL(9,6) | nullable |
 | home_lon | DECIMAL(9,6) | nullable |
 | preparation_minutes | INT | 身支度時間（分） |
+| reminder_minutes_before | INT | 出発X分前に通知 e.g. 30 |
 | timezone | VARCHAR(50) | デフォルト: Asia/Tokyo |
 | created_at | TIMESTAMP | |
 | updated_at | TIMESTAMP | |
@@ -53,33 +54,58 @@
 | tag_id | BIGINT FK → Tag | |
 | PRIMARY KEY | (schedule_id, tag_id) | |
 
-### TemplateTag（Template と Tag の中間テーブル）
-
-| カラム | 型 | 備考 |
-|--------|----|----|
-| template_id | BIGINT FK → Template | |
-| tag_id | BIGINT FK → Tag | |
-| PRIMARY KEY | (template_id, tag_id) | |
-
----
-
 ### Template（テンプレート）
+
+「1日全体の予定集合の雛形」。Template 自体は名前と種別のみ持ち、内部に複数の TemplateSchedule を持つ。
 
 | カラム | 型 | 備考 |
 |--------|----|----|
 | id | BIGINT PK | |
 | user_id | BIGINT FK → User | |
 | name | VARCHAR(100) | テンプレート名 |
-| destination_name | VARCHAR(255) | nullable |
-| destination_address | VARCHAR(255) | nullable |
-| destination_lat | DECIMAL(9,6) | nullable |
-| destination_lon | DECIMAL(9,6) | nullable |
-| travel_mode | ENUM | walking / cycling / transit / driving |
-| memo | TEXT | 準備事項 nullable |
+| template_category_id | BIGINT FK → TemplateCategory | nullable |
 | created_at | TIMESTAMP | |
 | updated_at | TIMESTAMP | |
 
 **対応エンドポイント:** `GET/POST /templates`, `GET/PUT/DELETE /templates/{id}`, `POST /templates/{id}/apply`
+
+---
+
+### TemplateCategory（テンプレートカテゴリマスタ）
+
+| カラム | 型 | 備考 |
+|--------|----|----|
+| id | BIGINT PK | |
+| name | VARCHAR(50) UNIQUE | seed 値: "仕事の日" / "在宅勤務" / "休日" |
+
+---
+
+### TemplateSchedule（テンプレート内の予定雛形）
+
+| カラム | 型 | 備考 |
+|--------|----|----|
+| id | BIGINT PK | |
+| template_id | BIGINT FK → Template | |
+| title | VARCHAR(255) | |
+| start_time | TIME | HH:MM 形式（日付なし） |
+| end_time | TIME | nullable |
+| destination_name | VARCHAR(255) | nullable |
+| destination_address | VARCHAR(255) | nullable |
+| destination_lat | DECIMAL(9,6) | nullable |
+| destination_lon | DECIMAL(9,6) | nullable |
+| travel_mode | ENUM | nullable |
+| memo | TEXT | nullable |
+| sort_order | INT | テンプレート内の表示順 |
+
+---
+
+### TemplateScheduleTag（TemplateSchedule と Tag の中間テーブル）
+
+| カラム | 型 | 備考 |
+|--------|----|----|
+| template_schedule_id | BIGINT FK → TemplateSchedule | |
+| tag_id | BIGINT FK → Tag | |
+| PRIMARY KEY | (template_schedule_id, tag_id) | |
 
 ---
 
@@ -118,7 +144,6 @@
 | weather_enabled | BOOLEAN | 天気通知 ON/OFF |
 | weather_notify_time | TIME | 毎朝の通知時刻 e.g. 07:00 |
 | reminder_enabled | BOOLEAN | 予定リマインダー ON/OFF |
-| reminder_minutes_before | INT | 出発X分前に通知 e.g. 30 |
 | created_at | TIMESTAMP | |
 | updated_at | TIMESTAMP | |
 
@@ -162,6 +187,7 @@ erDiagram
         decimal home_lat
         decimal home_lon
         int preparation_minutes
+        int reminder_minutes_before
         varchar timezone
         timestamp created_at
         timestamp updated_at
@@ -173,7 +199,6 @@ erDiagram
         boolean weather_enabled
         time weather_notify_time
         boolean reminder_enabled
-        int reminder_minutes_before
         timestamp created_at
         timestamp updated_at
     }
@@ -195,18 +220,33 @@ erDiagram
         bigint id PK
         bigint user_id FK
         varchar name
+        bigint template_category_id FK
+        timestamp created_at
+        timestamp updated_at
+    }
+
+    TemplateCategory {
+        bigint id PK
+        varchar name UK
+    }
+
+    TemplateSchedule {
+        bigint id PK
+        bigint template_id FK
+        varchar title
+        time start_time
+        time end_time
         varchar destination_name
         varchar destination_address
         decimal destination_lat
         decimal destination_lon
         enum travel_mode
         text memo
-        timestamp created_at
-        timestamp updated_at
+        int sort_order
     }
 
-    TemplateTag {
-        bigint template_id FK
+    TemplateScheduleTag {
+        bigint template_schedule_id FK
         bigint tag_id FK
     }
 
@@ -237,8 +277,10 @@ erDiagram
     User ||--o{ DeviceToken : "has"
     User ||--o{ Template : "owns"
     User ||--o{ Schedule : "owns"
-    Template ||--o{ TemplateTag : ""
-    Tag ||--o{ TemplateTag : ""
+    Template }o--|| TemplateCategory : "categorized by"
+    Template ||--o{ TemplateSchedule : "contains"
+    TemplateSchedule ||--o{ TemplateScheduleTag : ""
+    Tag ||--o{ TemplateScheduleTag : ""
     Schedule ||--o{ ScheduleTag : ""
     Tag ||--o{ ScheduleTag : ""
 ```
@@ -250,7 +292,7 @@ erDiagram
 | 項目 | 判断 | 理由 |
 |------|------|------|
 | `template_id` を Schedule に持つか | **持たない** | テンプレ適用はコピーのみ。テンプレ編集が既存予定に波及しない |
-| タグ管理 | **Tag + 中間テーブル（ScheduleTag / TemplateTag）** | Schedule と Template を独立して多対多管理 |
+| タグ管理 | **Tag + 中間テーブル（ScheduleTag / TemplateScheduleTag）** | Schedule と TemplateSchedule を独立して多対多管理 |
 | DeviceToken | **別テーブル** | 1ユーザー複数端末を想定 |
 | UserSettings | **User と別テーブル（1:1）** | プロフィールと設定を分離し、取得・更新を独立して行えるようにする |
 | 天気・経路データ | **DBに保存しない** | BFF として外部API（WeatherAPI.com 等）をリクエスト時に都度呼び出す |
@@ -264,8 +306,13 @@ erDiagram
 | パスワードリセット | **スコープ外** | `PasswordResetToken` テーブル不要 |
 | 繰り返し予定 | **`recurrence_rule VARCHAR(500)` を nullable で追加** | 現時点は非対応。将来 RRULE 形式で使用できるよう拡張可能な設計にする |
 | リマインダー設定 | **1つのみ（`reminder_minutes_before`）** | 現在は INT 1つ。将来の複数設定拡張を意識したコード設計にする |
+| `reminder_minutes_before` の配置 | **`UserSettings` に配置（登録時必須入力）** | 登録時に必須入力。`NotificationSettings` から移動 |
+| Template のコンセプト | **1日全体の予定集合の雛形** | Template 自体は名前と TemplateCategory のみ保持。複数の TemplateSchedule（予定の雛形）を内包 |
+| TemplateSchedule の時刻 | **固定時刻（HH:MM 形式）** | 日付なし TIME 型。apply 時に指定日付と組み合わせて TIMESTAMP の Schedule を生成 |
+| Template のタグ管理 | **TemplateScheduleTag（TemplateSchedule と Tag の中間テーブル）** | Template 直接へのタグ付けは廃止（旧 TemplateTag を削除） |
+| Template の種別分類 | **TemplateCategory マスタ** | Tag ではなく専用の TemplateCategory で分類。seed 値: **"仕事の日" / "在宅勤務" / "休日"（確定）** |
 | 経路 API | **OTP2（検証中）** | Phase 7 で詳細設計。現在選定中のためブロッカー状態 |
-| Suggestions（提案ロジック）| **スコープ外** | Phase 8 は実装しない |
+| Suggestions（提案ロジック）| **Gemini API を使って実装（確定）** | `GET /suggestions/today`（今日の提案）と `GET /suggestions/{schedule_id}`（予定ごとの提案）の 2 エンドポイント |
 
 ---
 

--- a/backend/docs/経路探索API設計調査.md
+++ b/backend/docs/経路探索API設計調査.md
@@ -1,0 +1,580 @@
+# 経路探索API設計調査
+
+> **目的:** Phase 7（Routes 実装）のブロッカー解消のため、OTP2 を使った経路探索 API の入出力設計を整理する。
+> **作成日:** 2026-03-01
+
+---
+
+## 1. 概要
+
+バックエンドは BFF（Backend For Frontend）として OTP2（OpenTripPlanner 2）をラップし、フロントエンドに2つのエンドポイントを提供する。
+
+| エンドポイント | 機能 |
+|---------------|------|
+| `POST /routes/search` | 経路検索。出発地・目的地・移動手段（・到着希望時刻）を受け取り、乗換案内付きの経路を返す |
+| `POST /routes/departure-time` | 出発時刻逆算。目的地と到着時刻を受け取り、「いつ家を出ればよいか（`leave_home_at`）」と「いつ身支度を始めればよいか（`start_preparation_at`）」を返す |
+
+OTP2 は Java ベースのオープンソース（LGPL）マルチモーダル経路探索エンジン。GraphQL API のみ提供（REST API は v2 で廃止）。
+
+---
+
+## 2. ユーザー仮説の検証
+
+> **仮説:** 「出発地点の緯度経度、目的地の緯度経度、到着時間があれば出発時刻が出せる」
+
+**仮説は正しい。かつ OTP2 が全区間を自動計算してくれる。**
+
+OTP2 の `planConnection(dateTime: { latestArrival: "..." })` に3つの情報を渡すだけで、
+
+1. 出発地 → 最寄り駅（徒歩）
+2. 最寄り駅 → 目的地最寄り駅（電車）
+3. 駅 → 目的地（徒歩）
+
+の全区間を考慮した最適出発時刻が `itinerary.start` に返ってくる。
+
+`itinerary.start` がそのまま「家を出る時刻（`leave_home_at`）」となる（OTP2 の origin に自宅座標を渡しているため、徒歩区間を含む全行程の出発点 = 家を出る時刻）。
+
+さらにサーバーサイドで `UserSettings.preparation_minutes` を引くことで「身支度を始める時刻（`start_preparation_at`）」を算出できる。
+
+---
+
+## 3. 必要な入力情報の整理
+
+### 3.1 `POST /routes/search` — リクエストパラメータ
+
+| パラメータ | 型 | 必須 | 取得元 | 説明 |
+|-----------|----|----|--------|------|
+| `origin_lat` | `float` | ○ | リクエスト or UserSettings | 出発地の緯度 |
+| `origin_lon` | `float` | ○ | リクエスト or UserSettings | 出発地の経度 |
+| `destination_lat` | `float` | ○ | リクエスト（Schedule から引き継ぎ） | 目的地の緯度 |
+| `destination_lon` | `float` | ○ | リクエスト（Schedule から引き継ぎ） | 目的地の経度 |
+| `travel_mode` | `string` | ○ | リクエスト（Schedule から引き継ぎ） | `transit` / `walking` / `cycling` / `driving`。詳細は § 8.3 参照 |
+| `arrival_time` | `string` | 任意 | リクエスト | 到着希望時刻（ISO 8601 JST）。省略時は現在時刻出発で最速経路を返す |
+
+> **UserSettings から自動補完できる項目:**
+> - `origin_lat` / `origin_lon` — リクエストに含まれない場合、認証済みユーザーの `UserSettings.home_lat` / `home_lon` を使用する
+
+### 3.2 `POST /routes/departure-time` — リクエストパラメータ
+
+| パラメータ | 型 | 必須 | 取得元 | 説明 |
+|-----------|----|----|--------|------|
+| `destination_lat` | `float` | ○ | リクエスト（Schedule から引き継ぎ） | 目的地の緯度 |
+| `destination_lon` | `float` | ○ | リクエスト（Schedule から引き継ぎ） | 目的地の経度 |
+| `arrival_time` | `string` | ○ | リクエスト（Schedule.start_at） | 到着希望時刻（ISO 8601 JST） |
+| `travel_mode` | `string` | ○ | リクエスト（Schedule から引き継ぎ） | `transit` / `walking` / `cycling` / `driving`。詳細は § 8.3 参照 |
+
+> **UserSettings から自動取得される項目（リクエスト不要）:**
+> - `origin_lat` / `origin_lon` — `UserSettings.home_lat` / `home_lon` をサーバーが自動取得
+> - `preparation_minutes` — `UserSettings.preparation_minutes` をサーバーが自動取得し `leave_home_at` 計算に使用
+
+---
+
+## 4. OTP2 GraphQL クエリ設計
+
+`planConnection` + `latestArrival` の組み合わせが OTP2 v2.7.0 以降の推奨形式。
+
+### 4.1 到着時刻指定（逆方向探索）クエリ
+
+```graphql
+query DepartureTimeSearch(
+  $originLat: Float!
+  $originLon: Float!
+  $destLat: Float!
+  $destLon: Float!
+  $latestArrival: OffsetDateTime!
+) {
+  planConnection(
+    origin: {
+      location: { coordinate: { latitude: $originLat, longitude: $originLon } }
+    }
+    destination: {
+      location: { coordinate: { latitude: $destLat, longitude: $destLon } }
+    }
+    dateTime: { latestArrival: $latestArrival }
+    modes: {
+      transit: { transit: [{ mode: RAIL }, { mode: SUBWAY }, { mode: BUS }] }
+      direct: [WALK]
+    }
+    first: 5
+  ) {
+    edges {
+      node {
+        start    # 出発すべき時刻（これが departure_time の答え）
+        end      # 到着時刻
+        duration
+        numberOfTransfers
+        legs {
+          mode
+          route {
+            shortName
+            longName
+            agency { name }
+          }
+          from {
+            name
+            stop { gtfsId }
+          }
+          to {
+            name
+            stop { gtfsId }
+          }
+          start { scheduledTime }
+          end   { scheduledTime }
+          headsign
+          interlineWithPreviousLeg
+          stopCalls {
+            stopLocation {
+              ... on Stop {
+                name
+                gtfsId
+              }
+            }
+            schedule {
+              scheduledDeparture
+              scheduledArrival
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+### 4.2 出発時刻指定（通常探索）クエリ
+
+```graphql
+query RouteSearch(
+  $originLat: Float!
+  $originLon: Float!
+  $destLat: Float!
+  $destLon: Float!
+  $earliestDeparture: OffsetDateTime!
+) {
+  planConnection(
+    origin: {
+      location: { coordinate: { latitude: $originLat, longitude: $originLon } }
+    }
+    destination: {
+      location: { coordinate: { latitude: $destLat, longitude: $destLon } }
+    }
+    dateTime: { earliestDeparture: $earliestDeparture }
+    modes: {
+      transit: { transit: [{ mode: RAIL }, { mode: SUBWAY }, { mode: BUS }] }
+      direct: [WALK]
+    }
+    first: 5
+  ) {
+    edges {
+      node {
+        start
+        end
+        duration
+        numberOfTransfers
+        legs {
+          mode
+          route {
+            shortName
+            longName
+            agency { name }
+          }
+          from { name }
+          to   { name }
+          start { scheduledTime }
+          end   { scheduledTime }
+          headsign
+          interlineWithPreviousLeg
+        }
+      }
+    }
+  }
+}
+```
+
+### 4.3 直接移動モード（walking / cycling / driving）クエリ
+
+`transit` 以外のモードは乗り換えなしの直接移動（`direct` のみ）を使用する。
+
+| travel_mode | OTP2 modes 構文 |
+|-------------|----------------|
+| `transit`   | `modes: { transit: { transit: [{ mode: RAIL }, { mode: SUBWAY }, { mode: BUS }] }, direct: [WALK] }` |
+| `walking`   | `modes: { direct: [WALK] }` |
+| `cycling`   | `modes: { direct: [BICYCLE] }` |
+| `driving`   | `modes: { direct: [CAR] }` |
+
+```graphql
+query DirectModeSearch(
+  $originLat: Float!
+  $originLon: Float!
+  $destLat: Float!
+  $destLon: Float!
+  $earliestDeparture: OffsetDateTime!
+  $mode: DirectMode!   # WALK / BICYCLE / CAR
+) {
+  planConnection(
+    origin: { location: { coordinate: { latitude: $originLat, longitude: $originLon } } }
+    destination: { location: { coordinate: { latitude: $destLat, longitude: $destLon } } }
+    dateTime: { earliestDeparture: $earliestDeparture }
+    modes: { direct: [$mode] }
+    first: 1   # 直接移動は 1件のみ
+  ) {
+    edges {
+      node {
+        start
+        end
+        duration
+        legs {
+          mode
+          from { name }
+          to   { name }
+          start { scheduledTime }
+          end   { scheduledTime }
+        }
+      }
+    }
+  }
+}
+```
+
+逆方向探索（`departure-time`）の場合は `dateTime: { latestArrival: $latestArrival }` に変更。
+
+---
+
+## 5. バックエンドAPIエンドポイント設計
+
+### 5.1 `POST /routes/search` — 経路検索
+
+**リクエスト**
+
+```jsonc
+{
+  "origin_lat": 35.6895,          // 省略時は UserSettings.home_lat を使用
+  "origin_lon": 139.6917,         // 省略時は UserSettings.home_lon を使用
+  "destination_lat": 35.6580,
+  "destination_lon": 139.7016,
+  "travel_mode": "transit",
+  "arrival_time": "2026-03-10T19:00:00+09:00"  // 任意。省略時は現在時刻出発
+}
+```
+
+**レスポンス `200 OK`**
+
+```jsonc
+{
+  "itineraries": [
+    {
+      "departure_time": "2026-03-10T18:12:00+09:00",
+      "arrival_time": "2026-03-10T18:58:00+09:00",
+      "duration_minutes": 46,
+      "number_of_transfers": 1,
+      "legs": [
+        {
+          "mode": "WALK",
+          "from_name": "出発地",
+          "to_name": "高円寺駅",
+          "departure_time": "2026-03-10T18:12:00+09:00",
+          "arrival_time": "2026-03-10T18:20:00+09:00",
+          "duration_minutes": 8
+        },
+        {
+          "mode": "RAIL",
+          "route_short_name": "中央線（快速）",
+          "route_long_name": "中央本線",
+          "agency_name": "JR東日本",
+          "headsign": "東京方面",
+          "from_name": "高円寺駅",
+          "to_name": "新宿駅",
+          "departure_time": "2026-03-10T18:23:00+09:00",
+          "arrival_time": "2026-03-10T18:29:00+09:00",
+          "duration_minutes": 6
+        },
+        {
+          "mode": "RAIL",
+          "route_short_name": "山手線",
+          "route_long_name": "山手線",
+          "agency_name": "JR東日本",
+          "headsign": "渋谷・品川方面",
+          "from_name": "新宿駅",
+          "to_name": "渋谷駅",
+          "departure_time": "2026-03-10T18:33:00+09:00",
+          "arrival_time": "2026-03-10T18:38:00+09:00",
+          "duration_minutes": 5
+        },
+        {
+          "mode": "WALK",
+          "from_name": "渋谷駅",
+          "to_name": "目的地",
+          "departure_time": "2026-03-10T18:38:00+09:00",
+          "arrival_time": "2026-03-10T18:58:00+09:00",
+          "duration_minutes": 20
+        }
+      ]
+    }
+  ]
+}
+```
+
+**`walking` レスポンス例**（legs は1件、transit 専用フィールドなし）：
+
+```jsonc
+{
+  "itineraries": [
+    {
+      "departure_time": "2026-03-10T18:12:00+09:00",
+      "arrival_time": "2026-03-10T18:40:00+09:00",
+      "duration_minutes": 28,
+      // number_of_transfers は walking/cycling/driving では返却しない
+      "legs": [
+        {
+          "mode": "WALK",
+          "from_name": "出発地",
+          "to_name": "目的地",
+          "departure_time": "2026-03-10T18:12:00+09:00",
+          "arrival_time": "2026-03-10T18:40:00+09:00",
+          "duration_minutes": 28
+          // route_short_name / agency_name / headsign なし
+        }
+      ]
+    }
+  ]
+}
+```
+
+`cycling` は `mode: "BICYCLE"`、`driving` は `mode: "CAR"` で同形式。
+
+---
+
+### 5.2 `POST /routes/departure-time` — 出発時刻逆算
+
+**リクエスト**
+
+```jsonc
+{
+  "destination_lat": 35.6580,
+  "destination_lon": 139.7016,
+  "arrival_time": "2026-03-10T19:00:00+09:00",
+  "travel_mode": "transit"
+  // origin_lat / origin_lon は UserSettings.home_lat / home_lon を自動取得
+  // preparation_minutes は UserSettings.preparation_minutes を自動取得
+}
+```
+
+**レスポンス `200 OK`**
+
+```jsonc
+{
+  "leave_home_at": "2026-03-10T18:12:00+09:00",         // OTP2 が算出した家を出る時刻（itinerary.start）
+  "start_preparation_at": "2026-03-10T17:42:00+09:00",   // leave_home_at - preparation_minutes（身支度を始める時刻）
+  "preparation_minutes": 30,                               // UserSettings から取得した値（確認用）
+  "arrival_time": "2026-03-10T19:00:00+09:00",            // リクエストで指定した到着時刻
+  "itinerary": {
+    "duration_minutes": 48,
+    "number_of_transfers": 1,
+    "legs": [
+      {
+        "mode": "WALK",
+        "from_name": "自宅付近",
+        "to_name": "高円寺駅",
+        "departure_time": "2026-03-10T18:12:00+09:00",
+        "arrival_time": "2026-03-10T18:20:00+09:00",
+        "duration_minutes": 8
+      },
+      {
+        "mode": "RAIL",
+        "route_short_name": "中央線（快速）",
+        "headsign": "東京方面",
+        "from_name": "高円寺駅",
+        "to_name": "新宿駅",
+        "departure_time": "2026-03-10T18:23:00+09:00",
+        "arrival_time": "2026-03-10T18:29:00+09:00",
+        "duration_minutes": 6
+      }
+    ]
+  }
+}
+```
+
+---
+
+## 6. 出発時刻逆算の仕組み
+
+OTP2 は `latestArrival` を指定することで**逆方向探索（Reverse Search）**を行う。
+
+通常の探索（`earliestDeparture`）が「出発時刻から最短の到着時刻を求める」のに対し、
+逆方向探索は「到着希望時刻から最遅の出発時刻を求める」。
+
+```
+通常:  出発時刻 → [OTP2探索] → 最速到着時刻
+逆算:  到着希望時刻 ← [OTP2逆方向探索] ← 最遅出発時刻
+```
+
+OTP2 が内部で以下を考慮して出発時刻を算出する：
+- 自宅 → 最寄り駅までの徒歩時間
+- 最寄り駅での電車待ち時間（時刻表ベース）
+- 乗車時間・乗り換え時間
+- 降車駅 → 目的地までの徒歩時間
+
+返却された `itinerary.start` の値が `leave_home_at`（家を出る時刻）となる。
+OTP2 の origin に自宅座標（`home_lat/home_lon`）を渡しているため、出発地点から徒歩区間を含む全行程の先頭時刻 = 家を出る時刻になる。
+
+---
+
+## 7. 身支度時間の計算
+
+`leave_home_at`（OTP2 が算出した家を出る時刻）から `UserSettings.preparation_minutes` を引くことで「身支度を始める時刻（`start_preparation_at`）」を算出する。
+
+```
+leave_home_at       = itinerary.start（OTP2 算出）
+start_preparation_at = leave_home_at - preparation_minutes（分）
+```
+
+**実装例（Python）:**
+
+```python
+from datetime import timedelta
+
+leave_home_at = itinerary["start"]  # OTP2 の応答から取得（= 家を出る時刻）
+preparation_minutes = user_settings.preparation_minutes  # UserSettings から取得
+
+start_preparation_at = leave_home_at - timedelta(minutes=preparation_minutes)
+```
+
+**具体例:**
+
+| 項目 | 値 |
+|------|-----|
+| 到着希望時刻（`arrival_time`） | `2026-03-10T19:00:00+09:00` |
+| OTP2 算出の家を出る時刻（`leave_home_at`） | `2026-03-10T18:12:00+09:00` |
+| 身支度時間（`preparation_minutes`） | 30 分 |
+| 身支度を始める時刻（`start_preparation_at`） | `2026-03-10T17:42:00+09:00` |
+
+---
+
+## 8. 実装上の注意点・制約
+
+### 8.1 GTFS 有効期限切れ問題
+
+現在 `learn-OpenTripPlanner/data/GTFS-data/` に生成済みの GTFS データは `end_date` が `2025-12-31` となっており**有効期限切れ**（現在 2026-03-01）。
+
+OTP2 は有効期限外の日付で経路検索を行うと結果を返さない。
+
+**対応方針:**
+1. TrainGTFSGenerator の設定で `end_date` を `2026-12-31` 以降に変更する
+2. `poetry run python src/main.py` を再実行して GTFS を再生成する
+3. 再生成後にグラフビルドを再実行する（`java -Xmx4G -jar otp.jar --build --save data/`）
+
+### 8.2 対応路線の範囲
+
+TrainGTFSGenerator で対応している**首都圏 22 事業者**のみ経路検索可能。
+
+| 事業者グループ | 主な路線 |
+|---------------|---------|
+| JR東日本 | 山手線・中央線・京浜東北線など 49 路線 |
+| 東京メトロ | 銀座線・丸ノ内線など 10 路線 |
+| 都営 | 地下鉄・荒川線・日暮里舎人ライナーなど 6 路線 |
+| 私鉄各社 | 東急・小田急・西武・東武・京急・京成・相鉄 等 |
+| その他 | 横浜市営地下鉄・つくばエクスプレス・多摩モノレール・ゆりかもめ 等 |
+
+**未対応路線（既知）:**
+- ~~京王線（`Keio-Train.gtfs.zip` が未生成）~~ **→ 生成済み（488 KB、有効期限 2026-12-31）**
+
+### 8.3 travel_mode の制約
+
+全4値（walking / cycling / transit / driving）に対応。`transit` モードはバス（BUS）を含む公共交通機関（RAIL / SUBWAY / BUS）を使用する。
+
+| `travel_mode` | 対応状況 | OTP2 direct/transit modes |
+|--------------|---------|--------------------------|
+| `transit`    | ✅ 対応  | `transit: [RAIL, SUBWAY, BUS], direct: [WALK]` |
+| `walking`    | ✅ 対応  | `direct: [WALK]` |
+| `cycling`    | ✅ 対応  | `direct: [BICYCLE]` |
+| `driving`    | ✅ 対応  | `direct: [CAR]` |
+
+各モードの legs フィールド差異：
+
+| フィールド | transit | walking | cycling | driving |
+|-----------|---------|---------|---------|---------|
+| `mode` | WALK / RAIL / SUBWAY / BUS | WALK | BICYCLE | CAR |
+| `route_short_name` | transit leg のみ | なし | なし | なし |
+| `agency_name` | transit leg のみ | なし | なし | なし |
+| `headsign` | transit leg のみ | なし | なし | なし |
+| `number_of_transfers` | あり | なし | なし | なし |
+
+4値以外の `travel_mode` でリクエストされた場合は `400 VALIDATION_ERROR` を返す。
+
+### 8.4 環境変数
+
+OTP2 のホスト先 URL は環境変数で管理する。
+
+```
+OTP2_GRAPHQL_URL=http://localhost:8080/otp/gtfs/v1
+```
+
+本番環境では Cloud Run 等でデプロイした OTP2 サーバーの URL を設定する。
+
+### 8.5 タイムゾーン
+
+すべての日時は **JST（+09:00）** で統一する。
+
+- リクエスト: ISO 8601 形式（`2026-03-10T19:00:00+09:00`）
+- OTP2 への送信: `OffsetDateTime` 形式（そのまま渡せる）
+- レスポンス: ISO 8601 形式（+09:00 付き）
+
+### 8.6 `UserSettings.home_lat` / `home_lon` が未設定の場合
+
+`POST /routes/departure-time` は `UserSettings.home_lat` / `home_lon` を必須として使用する。
+これらが `null` の場合はエラーを返す。
+
+---
+
+## 9. エラーコード一覧
+
+| エラーコード | HTTP ステータス | 発生条件 |
+|-------------|----------------|---------|
+| `ROUTE_NOT_FOUND` | 404 | OTP2 が指定条件で経路を見つけられなかった（GTFS 期限切れ含む） |
+| `OTP_UNAVAILABLE` | 503 | OTP2 サーバーへの接続に失敗した |
+| `HOME_LOCATION_NOT_SET` | 400 | `UserSettings.home_lat` / `home_lon` が未設定（`departure-time` エンドポイントで発生） |
+| `VALIDATION_ERROR` | 400 | `travel_mode` が 4値（transit/walking/cycling/driving）以外など |
+
+**エラーレスポンス形式（共通形式に準拠）:**
+
+```jsonc
+{
+  "error": {
+    "code": "ROUTE_NOT_FOUND",
+    "message": "指定した条件で経路が見つかりませんでした"
+  }
+}
+```
+
+---
+
+## 10. 未解決事項（TODO）
+
+| # | 事項 | 優先度 | 担当 |
+|---|------|--------|------|
+| T-1 | GTFS の有効期限修正・再生成（`end_date` を `2026-12-31` に変更して再実行） | ✅ 解消 | 全 GTFS が `end_date: 2026-12-31` で有効 |
+| T-2 | OTP2 のデプロイ先決定（Cloud Run / GCE / その他） | 高 | **後回し** — Phase 7 実装直前に決定 |
+| T-3 | 京王線 GTFS 未生成の対応方針（スコープ内/外の確認） | ✅ 解消 | `Keio-Train.gtfs.zip` は生成・対応済み |
+| T-4 | transit 以外の travel_mode 対応方針 | ✅ 完了 | 全4値対応（§ 8.3 参照） |
+| T-5 | OTP2 グラフビルド実行（セットアップ手順は `docs/api/外部経路探索API調査.md § 6` 参照） | ✅ 解消 | `graph.obj`（709 MB）ビルド済み |
+| T-6 | 動作検証クエリの実行（「2026-03-10 に渋谷へ 19:00 着」で `leave_home_at` が正しく返るか） | 高 | **残存** — デプロイ先確定後に実施 |
+
+---
+
+## 11. 参考リンク
+
+- [OTP2 公式ドキュメント](https://docs.opentripplanner.org/)
+- [OTP2 GraphQL API リファレンス](https://docs.opentripplanner.org/api/dev-2.x/graphql-gtfs/)
+- [planConnection クエリ](https://docs.opentripplanner.org/api/dev-2.x/graphql-gtfs/queries/planConnection)
+- [OTP2 GitHub](https://github.com/opentripplanner/OpenTripPlanner)
+- [TrainGTFSGenerator GitHub](https://github.com/fksms/TrainGTFSGenerator)
+
+---
+
+## 参考ドキュメント（相互リンク）
+
+- `docs/api/外部経路探索API調査.md` — API 候補比較・OTP2 機能検証・GTFS 状況・セットアップ手順
+- `../learn-OpenTripPlanner/OTP2-investigation-report.md` — GraphQL クエリサンプル・詳細検証結果
+- `backend/docs/データモデル草案.md` — UserSettings（home_lat/lon, preparation_minutes）・Schedule のデータ定義
+- `backend/docs/API詳細設計.md` — 既存エンドポイント設計（Routes は本ドキュメントで解消）
+- `backend/app/api/api仕様.md` — Routes エンドポイント一覧

--- a/backend/docs/開発タスク.md
+++ b/backend/docs/開発タスク.md
@@ -45,8 +45,8 @@
 
 ### 外部API
 
-- [x] 🟡 **Routes** 経路 API を選定する（Google Directions API / Yahoo! 乗換 API 等）— **OTP2**（検証中、Phase 7 で詳細設計）
-- [x] 🟢 **Suggestions** 提案ロジックのルールを定義する（例: 雨 × タグ=デート → 折り畳み傘）— **スコープ外**
+- [x] 🟡 **Routes** 経路 API を選定する（Google Directions API / Yahoo! 乗換 API 等）— **OTP2**（確定。GTFS・グラフビルド済み。デプロイ先は Phase 7 直前に決定）
+- [x] 🟢 **Suggestions** 提案ロジックのアプローチを決定する — **Gemini API を使って実装（確定）**
 
 ---
 
@@ -115,13 +115,15 @@
 
 ### Templates
 
-- [ ] 🟡 `Template` / `TemplateTag` モデルを作成しマイグレーションを実行する
-- [ ] 🟡 `GET /templates` を実装する
-- [ ] 🟡 `POST /templates` を実装する
+> Template は「1日の予定集合の雛形」。`Template` / `TemplateCategory` / `TemplateSchedule` / `TemplateScheduleTag` を実装する。
+
+- [ ] 🟡 `Template` / `TemplateCategory` / `TemplateSchedule` / `TemplateScheduleTag` モデルを作成しマイグレーションを実行する
+- [ ] 🟡 `GET /templates` を実装する（TemplateSchedule・TemplateCategory をネストして返す）
+- [ ] 🟡 `POST /templates` を実装する（schedules 配列を一括作成）
 - [ ] 🟡 `GET /templates/{id}` を実装する
 - [ ] 🟡 `PUT /templates/{id}` を実装する
 - [ ] 🟡 `DELETE /templates/{id}` を実装する
-- [ ] 🟡 `POST /templates/{id}/apply` を実装する（テンプレートからスケジュールをコピー作成）
+- [ ] 🟡 `POST /templates/{id}/apply` を実装する（`date` を受け取り TemplateSchedule の時刻と組み合わせて Schedule を複数作成）
 
 ---
 
@@ -155,18 +157,19 @@
 > 詳細は `API詳細設計.md § Routes` 参照
 
 - [ ] 🟢 外部経路 API クライアントを実装する（API 選定後）
-- [ ] 🟢 `POST /routes/search` を実装する
 - [ ] 🟢 `POST /routes/departure-time` を実装する
 
 ---
 
-## Phase 8: 提案 (Suggestions) ← ブロッカー待ち
+## Phase 8: 提案 (Suggestions) ← Gemini API を使って実装（確定）
 
-> Phase 0 の Suggestions（提案ロジック ルール定義）が完了するまで着手不可
+> **ブロッカー解消済み。** Gemini API を使った AI 提案として設計確定。
 > 詳細は `API詳細設計.md § Suggestions` 参照
 
-- [ ] 🟢 提案ルールを定義してロジックを実装する
-- [ ] 🟢 `GET /suggestions` を実装する
+- [ ] 🟡 Gemini API クライアントを実装する
+- [ ] 🟡 API キーを環境変数で管理する
+- [ ] 🟡 `GET /suggestions/today` を実装する（今日のスケジュール + 天気情報を Gemini API に渡して服装・持ち物の提案を生成）
+- [ ] 🟡 `GET /suggestions/{schedule_id}` を実装する（指定 Schedule の目的地・タグ・メモ情報を Gemini API に渡して周辺スポット・アドバイスを生成）
 
 ---
 


### PR DESCRIPTION
## Summary

- **経路探索API設計調査.md**: `learn-OpenTripPlanner` リポジトリ調査により判明した事実（GTFS 有効・京王線 GTFS 生成済み・graph.obj ビルド済み）を反映し、未解決事項 T-1/T-3/T-5 を ✅ 解消済みに更新。T-2（デプロイ先）は Phase 7 直前に決定する方針に変更
- **データモデル草案.md**: TemplateCategory の seed データ値が確定したため TBD を "仕事の日" / "在宅勤務" / "休日" に更新
- **開発タスク.md**: Phase 0 Routes 行の表記を「検証中」→「確定。GTFS・グラフビルド済み。デプロイ先は Phase 7 直前に決定」に更新

## Test plan

- [x] `経路探索API設計調査.md` の「未対応路線」で京王線が ~~打ち消し線~~ + 生成済み表記になっていること
- [x] `経路探索API設計調査.md` の未解決事項テーブルで T-1 / T-3 / T-5 が ✅ 解消済みになっていること
- [x] `データモデル草案.md` の TemplateCategory に "仕事の日" / "在宅勤務" / "休日" が記載されていること
- [x] `開発タスク.md` の Phase 0 Routes 行が「確定」表記になっていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)