### PR TITLE
docs: 案A(Cloud Run)確定版のインフラ構築手順書・設計ドキュメント一式を追加

### DIFF
--- a/infra/cloudbuild-backend.yaml
+++ b/infra/cloudbuild-backend.yaml
@@ -1,0 +1,46 @@
+steps:
+  # Step 1: Docker イメージをビルド
+  - name: 'gcr.io/cloud-builders/docker'
+    args:
+      - 'build'
+      - '-t'
+      - 'asia-northeast1-docker.pkg.dev/$PROJECT_ID/app/fastapi-backend:$COMMIT_SHA'
+      - '-t'
+      - 'asia-northeast1-docker.pkg.dev/$PROJECT_ID/app/fastapi-backend:latest'
+      - './backend'
+
+  # Step 2: Artifact Registry にプッシュ
+  - name: 'gcr.io/cloud-builders/docker'
+    args:
+      - 'push'
+      - '--all-tags'
+      - 'asia-northeast1-docker.pkg.dev/$PROJECT_ID/app/fastapi-backend'
+
+  # Step 3: Cloud Run にデプロイ
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+    entrypoint: gcloud
+    args:
+      - 'run'
+      - 'deploy'
+      - 'fastapi-backend'
+      - '--image=asia-northeast1-docker.pkg.dev/$PROJECT_ID/app/fastapi-backend:$COMMIT_SHA'
+      - '--region=asia-northeast1'
+      - '--memory=512Mi'
+      - '--cpu=1'
+      - '--min-instances=0'
+      - '--max-instances=10'
+      - '--port=8000'
+      - '--ingress=all'
+      - '--allow-unauthenticated'
+      - '--set-secrets=SUPABASE_URL=SUPABASE_URL:latest,SUPABASE_KEY=SUPABASE_KEY:latest,JWT_SECRET=JWT_SECRET:latest,WEATHERAPI_KEY=WEATHERAPI_KEY:latest,GEMINI_API_KEY=GEMINI_API_KEY:latest,OTP2_GRAPHQL_URL=OTP2_GRAPHQL_URL:latest'
+      - '--service-account=fastapi-sa@$PROJECT_ID.iam.gserviceaccount.com'
+      - '--timeout=60'
+
+images:
+  - 'asia-northeast1-docker.pkg.dev/$PROJECT_ID/app/fastapi-backend:$COMMIT_SHA'
+  - 'asia-northeast1-docker.pkg.dev/$PROJECT_ID/app/fastapi-backend:latest'
+
+timeout: '600s'
+
+options:
+  logging: CLOUD_LOGGING_ONLY

--- a/infra/cloudbuild-otp2.yaml
+++ b/infra/cloudbuild-otp2.yaml
@@ -1,0 +1,48 @@
+steps:
+  # Step 1: Docker イメージをビルド（graph.obj含むため大きい）
+  - name: 'gcr.io/cloud-builders/docker'
+    args:
+      - 'build'
+      - '-t'
+      - 'asia-northeast1-docker.pkg.dev/$PROJECT_ID/app/otp2-server:$COMMIT_SHA'
+      - '-t'
+      - 'asia-northeast1-docker.pkg.dev/$PROJECT_ID/app/otp2-server:latest'
+      - './otp2'
+    timeout: '900s'
+
+  # Step 2: Artifact Registry にプッシュ
+  - name: 'gcr.io/cloud-builders/docker'
+    args:
+      - 'push'
+      - '--all-tags'
+      - 'asia-northeast1-docker.pkg.dev/$PROJECT_ID/app/otp2-server'
+    timeout: '600s'
+
+  # Step 3: Cloud Run にデプロイ
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+    entrypoint: gcloud
+    args:
+      - 'run'
+      - 'deploy'
+      - 'otp2-server'
+      - '--image=asia-northeast1-docker.pkg.dev/$PROJECT_ID/app/otp2-server:$COMMIT_SHA'
+      - '--region=asia-northeast1'
+      - '--memory=4Gi'
+      - '--cpu=2'
+      - '--min-instances=1'
+      - '--max-instances=2'
+      - '--port=8080'
+      - '--ingress=internal'
+      - '--no-allow-unauthenticated'
+      - '--service-account=otp2-sa@$PROJECT_ID.iam.gserviceaccount.com'
+      - '--timeout=300'
+
+images:
+  - 'asia-northeast1-docker.pkg.dev/$PROJECT_ID/app/otp2-server:$COMMIT_SHA'
+  - 'asia-northeast1-docker.pkg.dev/$PROJECT_ID/app/otp2-server:latest'
+
+timeout: '1800s'
+
+options:
+  logging: CLOUD_LOGGING_ONLY
+  machineType: 'E2_HIGHCPU_8'

--- a/infra/docs/CI-CDパイプライン設計.md
+++ b/infra/docs/CI-CDパイプライン設計.md
@@ -1,0 +1,285 @@
+# CI/CD パイプライン設計
+
+> **構成:** 案A — Cloud Run マルチサービス構成（確定）
+> **クライアント:** iOS アプリ（React Native）— CI/CD対象外
+> **更新日:** 2026-03-05
+
+---
+
+## 1. パイプライン概要
+
+### 対象サービス
+
+| サービス | CI/CDツール | トリガー条件 | 構成ファイル |
+|---------|-----------|------------|------------|
+| fastapi-backend | Cloud Build | `backend/**` へのpush (main) | `infra/cloudbuild-backend.yaml` |
+| otp2-server | Cloud Build | `otp2/**` へのpush (main) | `infra/cloudbuild-otp2.yaml` |
+| iOS App | **対象外** | Xcode / EAS Build で管理 | — |
+
+### パイプラインフロー
+
+```
+GitHub (main branch)
+    │
+    ├─► Cloud Build Trigger: deploy-fastapi-backend
+    │     対象: backend/** の変更
+    │     1. docker build ./backend
+    │     2. docker push → Artifact Registry
+    │     3. gcloud run deploy fastapi-backend
+    │     所要時間: ~2-3分
+    │
+    └─► Cloud Build Trigger: deploy-otp2-server
+          対象: otp2/** の変更
+          1. docker build ./otp2 (graph.obj ~709MB含む)
+          2. docker push → Artifact Registry
+          3. gcloud run deploy otp2-server
+          所要時間: ~10-15分（イメージが大きいため）
+```
+
+---
+
+## 2. Cloud Build トリガー設定
+
+### 2.1 backend トリガー
+
+| 項目 | 値 |
+|------|-----|
+| トリガー名 | `deploy-fastapi-backend` |
+| イベントタイプ | ブランチへのプッシュ |
+| ソース | GitHub リポジトリ (main ブランチ) |
+| ファイルフィルタ（含む） | `backend/**` |
+| Cloud Build構成ファイル | `infra/cloudbuild-backend.yaml` |
+| サービスアカウント | デフォルト Cloud Build SA |
+
+### 2.2 otp2 トリガー
+
+| 項目 | 値 |
+|------|-----|
+| トリガー名 | `deploy-otp2-server` |
+| イベントタイプ | ブランチへのプッシュ |
+| ソース | GitHub リポジトリ (main ブランチ) |
+| ファイルフィルタ（含む） | `otp2/**` |
+| Cloud Build構成ファイル | `infra/cloudbuild-otp2.yaml` |
+| サービスアカウント | デフォルト Cloud Build SA |
+| タイムアウト | 1800秒（30分） |
+
+---
+
+## 3. cloudbuild-backend.yaml 詳細
+
+**ファイル:** `infra/cloudbuild-backend.yaml`
+
+```yaml
+steps:
+  # Step 1: Docker イメージをビルド
+  - name: 'gcr.io/cloud-builders/docker'
+    args:
+      - 'build'
+      - '-t'
+      - 'asia-northeast1-docker.pkg.dev/$PROJECT_ID/app/fastapi-backend:$COMMIT_SHA'
+      - '-t'
+      - 'asia-northeast1-docker.pkg.dev/$PROJECT_ID/app/fastapi-backend:latest'
+      - './backend'
+
+  # Step 2: Artifact Registry にプッシュ
+  - name: 'gcr.io/cloud-builders/docker'
+    args:
+      - 'push'
+      - '--all-tags'
+      - 'asia-northeast1-docker.pkg.dev/$PROJECT_ID/app/fastapi-backend'
+
+  # Step 3: Cloud Run にデプロイ
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+    entrypoint: gcloud
+    args:
+      - 'run'
+      - 'deploy'
+      - 'fastapi-backend'
+      - '--image=asia-northeast1-docker.pkg.dev/$PROJECT_ID/app/fastapi-backend:$COMMIT_SHA'
+      - '--region=asia-northeast1'
+      - '--memory=512Mi'
+      - '--cpu=1'
+      - '--min-instances=0'
+      - '--max-instances=10'
+      - '--port=8000'
+      - '--ingress=all'
+      - '--allow-unauthenticated'
+      - '--set-secrets=SUPABASE_URL=SUPABASE_URL:latest,SUPABASE_KEY=SUPABASE_KEY:latest,JWT_SECRET=JWT_SECRET:latest,WEATHERAPI_KEY=WEATHERAPI_KEY:latest,GEMINI_API_KEY=GEMINI_API_KEY:latest,OTP2_GRAPHQL_URL=OTP2_GRAPHQL_URL:latest'
+      - '--service-account=fastapi-sa@$PROJECT_ID.iam.gserviceaccount.com'
+      - '--timeout=60'
+
+images:
+  - 'asia-northeast1-docker.pkg.dev/$PROJECT_ID/app/fastapi-backend:$COMMIT_SHA'
+  - 'asia-northeast1-docker.pkg.dev/$PROJECT_ID/app/fastapi-backend:latest'
+
+timeout: '600s'
+
+options:
+  logging: CLOUD_LOGGING_ONLY
+```
+
+### ポイント
+
+- `$COMMIT_SHA` タグでイミュータブルなイメージ管理
+- `latest` タグも付与（手動参照用）
+- `--set-secrets` で Secret Manager から環境変数を注入
+- `--service-account` でカスタム SA を指定
+- タイムアウト 600秒（10分）で十分
+
+---
+
+## 4. cloudbuild-otp2.yaml 詳細
+
+**ファイル:** `infra/cloudbuild-otp2.yaml`
+
+```yaml
+steps:
+  # Step 1: Docker イメージをビルド（graph.obj含むため大きい）
+  - name: 'gcr.io/cloud-builders/docker'
+    args:
+      - 'build'
+      - '-t'
+      - 'asia-northeast1-docker.pkg.dev/$PROJECT_ID/app/otp2-server:$COMMIT_SHA'
+      - '-t'
+      - 'asia-northeast1-docker.pkg.dev/$PROJECT_ID/app/otp2-server:latest'
+      - './otp2'
+    timeout: '900s'
+
+  # Step 2: Artifact Registry にプッシュ
+  - name: 'gcr.io/cloud-builders/docker'
+    args:
+      - 'push'
+      - '--all-tags'
+      - 'asia-northeast1-docker.pkg.dev/$PROJECT_ID/app/otp2-server'
+    timeout: '600s'
+
+  # Step 3: Cloud Run にデプロイ
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+    entrypoint: gcloud
+    args:
+      - 'run'
+      - 'deploy'
+      - 'otp2-server'
+      - '--image=asia-northeast1-docker.pkg.dev/$PROJECT_ID/app/otp2-server:$COMMIT_SHA'
+      - '--region=asia-northeast1'
+      - '--memory=4Gi'
+      - '--cpu=2'
+      - '--min-instances=1'
+      - '--max-instances=2'
+      - '--port=8080'
+      - '--ingress=internal'
+      - '--no-allow-unauthenticated'
+      - '--service-account=otp2-sa@$PROJECT_ID.iam.gserviceaccount.com'
+      - '--timeout=300'
+
+images:
+  - 'asia-northeast1-docker.pkg.dev/$PROJECT_ID/app/otp2-server:$COMMIT_SHA'
+  - 'asia-northeast1-docker.pkg.dev/$PROJECT_ID/app/otp2-server:latest'
+
+timeout: '1800s'  # 30分（ビルド+プッシュに時間がかかるため）
+
+options:
+  logging: CLOUD_LOGGING_ONLY
+  machineType: 'E2_HIGHCPU_8'  # ビルド高速化のためハイスペックマシン使用
+```
+
+### ポイント
+
+- **タイムアウト 1800秒（30分）**: graph.obj (~709MB) を含むイメージビルド・プッシュに時間がかかるため
+- **`E2_HIGHCPU_8`**: ビルド高速化のためハイスペックマシンを使用（無料枠を超える場合は `E2_MEDIUM` に変更）
+- `--ingress=internal`: 外部アクセス不可
+- `--no-allow-unauthenticated`: IAM認証必須
+- `--min-instances=1`: 常時起動を保証
+
+---
+
+## 5. ブランチ戦略
+
+```
+main ─────────────────────────────────── 本番環境（Cloud Build自動デプロイ）
+  │
+  └── feature/* ─────────────────────── 機能開発（CI/CDトリガーなし）
+```
+
+| ブランチ | CI/CD | 用途 |
+|---------|-------|------|
+| `main` | Cloud Build 自動デプロイ | 本番環境 |
+| `feature/*` | なし | 機能開発ブランチ |
+
+**ハッカソン規模のため、シンプルなブランチ戦略を採用:**
+- `main` への push で自動デプロイ
+- staging/develop 環境は不要（必要時に追加可能）
+- Pull Request のマージで main にデプロイ
+
+---
+
+## 6. ロールバック手順
+
+### 方法1: Cloud Run リビジョン切り替え（推奨・最速）
+
+```bash
+# 現在のリビジョン一覧を確認
+gcloud run revisions list --service=fastapi-backend --region=asia-northeast1
+
+# 特定のリビジョンにトラフィックを100%切り替え
+gcloud run services update-traffic fastapi-backend \
+  --region=asia-northeast1 \
+  --to-revisions=fastapi-backend-REVISION_ID=100
+```
+
+所要時間: **数秒**（既存リビジョンへのルーティング変更のみ）
+
+### 方法2: 過去イメージの再デプロイ
+
+```bash
+# Artifact Registry のイメージ一覧
+gcloud artifacts docker images list \
+  asia-northeast1-docker.pkg.dev/PROJECT_ID/app/fastapi-backend
+
+# 特定のコミットSHAのイメージで再デプロイ
+gcloud run deploy fastapi-backend \
+  --image=asia-northeast1-docker.pkg.dev/PROJECT_ID/app/fastapi-backend:COMMIT_SHA \
+  --region=asia-northeast1
+```
+
+所要時間: **1-2分**（新リビジョン作成）
+
+### 方法3: git revert + 自動デプロイ
+
+```bash
+# 問題のコミットを revert
+git revert HEAD
+git push origin main
+# Cloud Build が自動でデプロイ
+```
+
+所要時間: **2-5分**（ビルド+デプロイ）
+
+---
+
+## 7. ビルド最適化
+
+### Docker レイヤーキャッシュ
+
+**backend/Dockerfile** は既に最適化済み:
+1. `requirements.txt` を先にコピー → 依存関係インストール
+2. アプリコードを最後にコピー
+3. コード変更時は依存関係レイヤーがキャッシュされる
+
+### OTP2 ビルドの注意点
+
+- `graph.obj` (~709MB) は変更頻度が低いため、Dockerfile のレイヤー順序で先にコピー
+- GTFS データ更新時のみ graph.obj が変わり、フルリビルドが必要
+- Cloud Build の `machineType: E2_HIGHCPU_8` でビルド時間を短縮
+
+### Artifact Registry クリーンアップ
+
+古いイメージの自動削除を設定:
+
+```bash
+# 30日以上前のイメージを削除するクリーンアップポリシー
+gcloud artifacts repositories set-cleanup-policies app \
+  --project=PROJECT_ID \
+  --location=asia-northeast1 \
+  --policy=infra/cleanup-policy.json
+```

--- a/infra/docs/アーキテクチャ図.md
+++ b/infra/docs/アーキテクチャ図.md
@@ -1,0 +1,225 @@
+# アーキテクチャ図
+
+> **構成:** 案A — Cloud Run マルチサービス構成（確定）
+> **クライアント:** iOS アプリ（React Native）
+> **更新日:** 2026-03-05
+
+---
+
+## 1. システム全体構成図
+
+```mermaid
+graph TB
+    subgraph "クライアント"
+        iOS["iOS App<br/>(React Native)"]
+    end
+
+    subgraph "GCP Project (asia-northeast1)"
+        subgraph "Cloud Run Services"
+            FastAPI["fastapi-backend<br/>1vCPU / 512MB<br/>min=0, max=10<br/>Port 8000<br/>--ingress all"]
+            OTP2["otp2-server<br/>2vCPU / 4GB<br/>min=1, max=2<br/>Port 8080<br/>--ingress internal"]
+        end
+
+        subgraph "CI/CD"
+            CB["Cloud Build"]
+            AR["Artifact Registry<br/>(Docker Images)"]
+        end
+
+        subgraph "管理サービス"
+            SM["Secret Manager"]
+            CL["Cloud Logging"]
+            CM["Cloud Monitoring"]
+        end
+    end
+
+    subgraph "外部サービス"
+        Supabase["Supabase<br/>(PostgreSQL + Auth)"]
+        Weather["WeatherAPI.com"]
+        Gemini["Google Gemini API"]
+        FCM["Firebase Cloud Messaging"]
+        APNs["Apple Push<br/>Notification Service"]
+    end
+
+    GitHub["GitHub Repository"]
+
+    iOS -- "HTTPS (JWT認証)" --> FastAPI
+    FastAPI -- "Internal HTTP<br/>(IAM認証)" --> OTP2
+    FastAPI -- "HTTPS" --> Supabase
+    FastAPI -- "HTTPS" --> Weather
+    FastAPI -- "HTTPS" --> Gemini
+    FastAPI -- "FCM SDK" --> FCM
+    FCM -- "APNs Protocol" --> APNs
+    APNs -- "Push通知" --> iOS
+
+    GitHub -- "Push Trigger" --> CB
+    CB -- "docker push" --> AR
+    AR -- "deploy" --> FastAPI
+    AR -- "deploy" --> OTP2
+
+    FastAPI -. "読み取り" .-> SM
+    CL -. "ログ収集" .-> FastAPI
+    CL -. "ログ収集" .-> OTP2
+    CM -. "メトリクス" .-> FastAPI
+    CM -. "メトリクス" .-> OTP2
+```
+
+---
+
+## 2. ASCII ダイアグラム
+
+Mermaid非対応環境向けのテキスト図。
+
+```
+                    ┌──────────────────┐
+                    │   iOS App        │
+                    │  (React Native)  │
+                    └────────┬─────────┘
+                             │ HTTPS (JWT認証)
+                             ▼
+┌────────────────────────────────────────────────────────┐
+│                  GCP Project (asia-northeast1)          │
+│                                                         │
+│  ┌───────────────┐     ┌────────────────────────────┐  │
+│  │ Cloud Build    │◄────│ GitHub (Push Trigger)       │  │
+│  │ (CI/CD)        │     └────────────────────────────┘  │
+│  └──────┬────────┘                                      │
+│         │ Build & Deploy                                │
+│         ▼                                               │
+│  ┌──────────────────┐                                   │
+│  │ Artifact Registry │                                   │
+│  │ (Docker Images)   │                                   │
+│  └──────┬───────────┘                                   │
+│         │                                               │
+│  ┌──────┴───────────────────────────────────────────┐  │
+│  │              Cloud Run Services                   │  │
+│  │                                                    │  │
+│  │  ┌─────────────────────┐  ┌────────────────────┐ │  │
+│  │  │ fastapi-backend      │  │ otp2-server        │ │  │
+│  │  │ (min=0, max=10)      │  │ (min=1, max=2)     │ │  │
+│  │  │ 1vCPU / 512MB        │  │ 2vCPU / 4GB        │ │  │
+│  │  │ Port: 8000           │  │ Port: 8080         │ │  │
+│  │  │ 公開 (ingress all)   │  │ 内部のみ (internal)│ │  │
+│  │  └──────────┬───────────┘  └──────▲─────────────┘ │  │
+│  │             │   Internal HTTP      │               │  │
+│  │             │   (IAM認証)          │               │  │
+│  │             └──────────────────────┘               │  │
+│  └────────────────────────────────────────────────────┘  │
+│                                                         │
+│  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐  │
+│  │ Secret Mgr   │  │ Cloud        │  │ Cloud        │  │
+│  │ (API Keys)   │  │ Logging      │  │ Monitoring   │  │
+│  └──────────────┘  └──────────────┘  └──────────────┘  │
+└────────────────────────────────────────────────────────┘
+         │                    │               │
+         ▼                    ▼               ▼
+  ┌──────────────┐   ┌──────────────┐  ┌─────────────┐
+  │ Supabase     │   │ WeatherAPI   │  │ Gemini API  │
+  │ (PostgreSQL) │   │              │  │             │
+  └──────────────┘   └──────────────┘  └─────────────┘
+```
+
+---
+
+## 3. デプロイフロー図
+
+```mermaid
+sequenceDiagram
+    participant Dev as 開発者
+    participant GH as GitHub (main)
+    participant CB as Cloud Build
+    participant AR as Artifact Registry
+    participant CR as Cloud Run
+
+    Dev->>GH: git push (backend/**)
+    GH->>CB: Push Trigger発火
+    CB->>CB: docker build ./backend
+    CB->>AR: docker push (fastapi-backend:COMMIT_SHA)
+    CB->>CR: gcloud run deploy fastapi-backend
+    CR-->>CB: デプロイ完了
+
+    Note over Dev,CR: OTP2も同様のフロー（otp2/** トリガー）
+```
+
+```
+GitHub Push (main branch)
+    │
+    ├─► Cloud Build Trigger (backend/**)
+    │     1. docker build fastapi-backend
+    │     2. push to Artifact Registry
+    │     3. gcloud run deploy fastapi-backend
+    │
+    └─► Cloud Build Trigger (otp2/**)
+          1. docker build otp2-server (graph.obj込み, ~1GB)
+          2. push to Artifact Registry
+          3. gcloud run deploy otp2-server
+
+※ iOS アプリは Xcode / EAS Build で管理（GCP CI/CD対象外）
+```
+
+---
+
+## 4. データフロー図
+
+```mermaid
+sequenceDiagram
+    participant App as iOS App
+    participant API as FastAPI Backend
+    participant OTP as OTP2 Server
+    participant DB as Supabase
+    participant Ext as External APIs
+
+    Note over App,Ext: 経路探索リクエスト
+    App->>API: GET /api/v1/routes (JWT Bearer)
+    API->>API: JWT検証
+    API->>OTP: GraphQL query (IAM token)
+    OTP-->>API: 経路データ (JSON)
+    API->>Ext: GET weather data
+    Ext-->>API: 天気データ
+    API->>Ext: POST Gemini (経路+天気→提案生成)
+    Ext-->>API: AI提案テキスト
+    API-->>App: 統合レスポンス (JSON)
+```
+
+---
+
+## 5. プッシュ通知フロー図
+
+```mermaid
+sequenceDiagram
+    participant App as iOS App
+    participant API as FastAPI Backend
+    participant FCM as Firebase CM
+    participant APNs as Apple APNs
+
+    Note over App,APNs: デバイストークン登録
+    App->>App: FCM SDK初期化
+    App->>FCM: デバイストークン取得
+    FCM-->>App: FCM Token
+    App->>API: POST /api/v1/devices (token登録)
+    API->>DB: トークン保存
+
+    Note over App,APNs: 通知送信
+    API->>FCM: FCM Send API (token指定)
+    FCM->>APNs: APNs経由で配信
+    APNs->>App: プッシュ通知表示
+```
+
+---
+
+## 6. サービス仕様サマリー
+
+| サービス | 実行環境 | CPU / Memory | インスタンス | 公開範囲 | ポート |
+|---------|---------|------------|------------|---------|-------|
+| fastapi-backend | Cloud Run | 1 vCPU / 512MB | 0〜10 | 外部公開 (HTTPS) | 8000 |
+| otp2-server | Cloud Run | 2 vCPU / 4GB | 1〜2 | 内部のみ | 8080 |
+
+## 7. コスト見積もり（月額）
+
+| 項目 | 料金 | 備考 |
+|------|------|------|
+| Cloud Run (FastAPI) | ~$0 | 無料枠内（200万リクエスト/月） |
+| Cloud Run (OTP2, min=1) | ~$30-50 | 4GB RAM × 1インスタンス常時起動 |
+| Artifact Registry | ~$1 | ストレージ料金のみ |
+| Cloud Build | ~$0 | 120分/日の無料枠内 |
+| Secret Manager | ~$0 | 少数のシークレット |
+| **合計** | **~$30-50/月** | Firebase Hosting不要で削減 |

--- a/infra/docs/インフラ構築手順書.md
+++ b/infra/docs/インフラ構築手順書.md
@@ -1,0 +1,839 @@
+# インフラ構築手順書
+
+> **構成:** 案A — Cloud Run マルチサービス構成（確定）
+> **クライアント:** iOS アプリ（React Native）
+> **リージョン:** asia-northeast1（東京）
+> **更新日:** 2026-03-05
+
+---
+
+## 目次
+
+1. [前提条件](#0-前提条件)
+2. [GCPプロジェクトセットアップ](#1-gcpプロジェクトセットアップ)
+3. [必要なAPIの有効化](#2-必要なapiの有効化)
+4. [IAM設定](#3-iam設定)
+5. [Artifact Registry セットアップ](#4-artifact-registry-セットアップ)
+6. [Cloud Secret Manager セットアップ](#5-cloud-secret-manager-セットアップ)
+7. [Cloud Run デプロイ: FastAPI Backend](#6-cloud-run-デプロイ-fastapi-backend)
+8. [Cloud Run デプロイ: OTP2 Server](#7-cloud-run-デプロイ-otp2-server)
+9. [サービス間通信の設定](#8-サービス間通信の設定)
+10. [Cloud Build CI/CD セットアップ](#9-cloud-build-cicd-セットアップ)
+11. [ドメイン・SSL設定（オプション）](#10-ドメインssl設定オプション)
+12. [FCM プッシュ通知設定](#11-fcm-プッシュ通知設定)
+13. [モニタリング・アラート設定](#12-モニタリングアラート設定)
+14. [コスト管理](#13-コスト管理)
+15. [付録](#付録)
+
+---
+
+## 0. 前提条件
+
+### 必要なツール
+
+| ツール | バージョン | インストール確認 |
+|--------|-----------|----------------|
+| gcloud CLI | 最新版 | `gcloud version` |
+| Docker Desktop | 最新版 | `docker --version` |
+| Git | 最新版 | `git --version` |
+
+### 必要なアカウント・キー
+
+- [x] GCP アカウント（請求先アカウント設定済み）
+- [x] GitHub アカウント（リポジトリアクセス権あり）
+- [x] Supabase プロジェクト作成済み → `SUPABASE_URL`, `SUPABASE_KEY` 取得済み
+- [x] WeatherAPI.com アカウント → `WEATHERAPI_KEY` 取得済み
+- [x] Google AI Studio → `GEMINI_API_KEY` 取得済み
+- [x] Apple Developer アカウント（プッシュ通知設定用）
+
+### 変数の準備
+
+以降の手順で使用する変数を設定する:
+
+```bash
+# プロジェクトID（一意な名前を設定）
+export PROJECT_ID="tenichi-hackathon"
+
+# リージョン
+export REGION="asia-northeast1"
+
+# Artifact Registry リポジトリ名
+export AR_REPO="app"
+```
+
+---
+
+## 1. GCPプロジェクトセットアップ
+
+### 1.1 gcloud CLI の認証
+
+```bash
+# Google アカウントでログイン
+gcloud auth login
+
+# Application Default Credentials の設定
+gcloud auth application-default login
+```
+
+### 1.2 プロジェクトの作成
+
+```bash
+# 新規プロジェクト作成
+gcloud projects create $PROJECT_ID --name="tenichi-hackathon"
+
+# プロジェクトをデフォルトに設定
+gcloud config set project $PROJECT_ID
+```
+
+### 1.3 請求先アカウントのリンク
+
+```bash
+# 請求先アカウント一覧を確認
+gcloud billing accounts list
+
+# 請求先アカウントをプロジェクトにリンク
+gcloud billing projects link $PROJECT_ID \
+  --billing-account=BILLING_ACCOUNT_ID
+```
+
+> **注意:** `BILLING_ACCOUNT_ID` は `gcloud billing accounts list` で確認した ID に置き換える。
+
+### 1.4 デフォルトリージョンの設定
+
+```bash
+gcloud config set run/region $REGION
+gcloud config set artifacts/location $REGION
+```
+
+### 確認
+
+```bash
+gcloud config list
+# project = tenichi-hackathon
+# run/region = asia-northeast1
+```
+
+---
+
+## 2. 必要なAPIの有効化
+
+```bash
+gcloud services enable \
+  run.googleapis.com \
+  cloudbuild.googleapis.com \
+  artifactregistry.googleapis.com \
+  secretmanager.googleapis.com \
+  cloudresourcemanager.googleapis.com \
+  logging.googleapis.com \
+  monitoring.googleapis.com \
+  iam.googleapis.com
+```
+
+### 確認
+
+```bash
+gcloud services list --enabled --filter="NAME:(run OR cloudbuild OR artifactregistry OR secretmanager)"
+```
+
+期待される出力:
+```
+NAME                                TITLE
+artifactregistry.googleapis.com     Artifact Registry API
+cloudbuild.googleapis.com           Cloud Build API
+run.googleapis.com                  Cloud Run Admin API
+secretmanager.googleapis.com        Secret Manager API
+```
+
+---
+
+## 3. IAM設定
+
+### 3.1 プロジェクト番号の取得
+
+```bash
+export PROJECT_NUMBER=$(gcloud projects describe $PROJECT_ID --format='value(projectNumber)')
+echo "Project Number: $PROJECT_NUMBER"
+```
+
+### 3.2 Cloud Run 用サービスアカウントの作成
+
+#### FastAPI Backend 用
+
+```bash
+gcloud iam service-accounts create fastapi-sa \
+  --display-name="FastAPI Backend Service Account"
+```
+
+#### OTP2 Server 用
+
+```bash
+gcloud iam service-accounts create otp2-sa \
+  --display-name="OTP2 Server Service Account"
+```
+
+### 3.3 Cloud Build サービスアカウントへの権限付与
+
+Cloud Build のデフォルト SA に Cloud Run デプロイ権限を付与する。
+
+```bash
+# Cloud Run 管理者
+gcloud projects add-iam-policy-binding $PROJECT_ID \
+  --member="serviceAccount:${PROJECT_NUMBER}@cloudbuild.gserviceaccount.com" \
+  --role="roles/run.admin"
+
+# サービスアカウントユーザー（Cloud Run にカスタムSAを指定するため）
+gcloud projects add-iam-policy-binding $PROJECT_ID \
+  --member="serviceAccount:${PROJECT_NUMBER}@cloudbuild.gserviceaccount.com" \
+  --role="roles/iam.serviceAccountUser"
+
+# Artifact Registry 書き込み
+gcloud projects add-iam-policy-binding $PROJECT_ID \
+  --member="serviceAccount:${PROJECT_NUMBER}@cloudbuild.gserviceaccount.com" \
+  --role="roles/artifactregistry.writer"
+```
+
+### 確認
+
+```bash
+# 作成したサービスアカウントの一覧
+gcloud iam service-accounts list
+
+# 期待される出力:
+# fastapi-sa@PROJECT_ID.iam.gserviceaccount.com
+# otp2-sa@PROJECT_ID.iam.gserviceaccount.com
+# PROJECT_NUMBER@cloudbuild.gserviceaccount.com
+```
+
+---
+
+## 4. Artifact Registry セットアップ
+
+### 4.1 Docker リポジトリの作成
+
+```bash
+gcloud artifacts repositories create $AR_REPO \
+  --repository-format=docker \
+  --location=$REGION \
+  --description="Tenichi app container images"
+```
+
+### 4.2 Docker 認証の設定
+
+```bash
+gcloud auth configure-docker ${REGION}-docker.pkg.dev
+```
+
+### 確認
+
+```bash
+gcloud artifacts repositories list --location=$REGION
+
+# 期待される出力:
+# REPOSITORY  FORMAT  ...  LOCATION         ...
+# app         DOCKER  ...  asia-northeast1  ...
+```
+
+---
+
+## 5. Cloud Secret Manager セットアップ
+
+### 5.1 シークレットの作成
+
+各シークレットを作成し、値を設定する。
+
+```bash
+# SUPABASE_URL
+echo -n "https://xxxxx.supabase.co" | \
+  gcloud secrets create SUPABASE_URL --data-file=-
+
+# SUPABASE_KEY
+echo -n "eyJhbGciOiJIUzI1NiIsInR..." | \
+  gcloud secrets create SUPABASE_KEY --data-file=-
+
+# JWT_SECRET
+echo -n "your-jwt-secret-key" | \
+  gcloud secrets create JWT_SECRET --data-file=-
+
+# WEATHERAPI_KEY
+echo -n "your-weather-api-key" | \
+  gcloud secrets create WEATHERAPI_KEY --data-file=-
+
+# GEMINI_API_KEY
+echo -n "your-gemini-api-key" | \
+  gcloud secrets create GEMINI_API_KEY --data-file=-
+
+# OTP2_GRAPHQL_URL（後で Cloud Run の内部URLに更新する）
+echo -n "placeholder" | \
+  gcloud secrets create OTP2_GRAPHQL_URL --data-file=-
+```
+
+> **注意:** `echo -n` の `-n` オプションで末尾の改行を除去すること。
+
+### 5.2 FastAPI サービスアカウントにシークレットアクセス権を付与
+
+```bash
+for SECRET in SUPABASE_URL SUPABASE_KEY JWT_SECRET WEATHERAPI_KEY GEMINI_API_KEY OTP2_GRAPHQL_URL; do
+  gcloud secrets add-iam-policy-binding $SECRET \
+    --member="serviceAccount:fastapi-sa@${PROJECT_ID}.iam.gserviceaccount.com" \
+    --role="roles/secretmanager.secretAccessor"
+done
+```
+
+### 確認
+
+```bash
+# シークレット一覧
+gcloud secrets list
+
+# 期待される出力（6つ）:
+# NAME             CREATED              ...
+# SUPABASE_URL     2026-03-05T...       ...
+# SUPABASE_KEY     2026-03-05T...       ...
+# JWT_SECRET       2026-03-05T...       ...
+# WEATHERAPI_KEY   2026-03-05T...       ...
+# GEMINI_API_KEY   2026-03-05T...       ...
+# OTP2_GRAPHQL_URL 2026-03-05T...       ...
+```
+
+---
+
+## 6. Cloud Run デプロイ: FastAPI Backend
+
+### 6.1 ローカルでのビルド確認（オプション）
+
+```bash
+cd /path/to/tenichi-hackathon
+
+# ローカルでビルド確認
+docker build -t fastapi-backend:test ./backend
+
+# ローカル起動テスト
+docker run -p 8000:8000 \
+  -e SUPABASE_URL=test \
+  -e SUPABASE_KEY=test \
+  -e JWT_SECRET=test \
+  -e WEATHERAPI_KEY=test \
+  -e GEMINI_API_KEY=test \
+  -e OTP2_GRAPHQL_URL=http://localhost:8080/otp/gtfs/v1 \
+  fastapi-backend:test
+```
+
+### 6.2 イメージのビルド＆プッシュ
+
+```bash
+# Cloud Build でリモートビルド＆プッシュ（推奨）
+gcloud builds submit ./backend \
+  --tag=${REGION}-docker.pkg.dev/${PROJECT_ID}/${AR_REPO}/fastapi-backend:v1
+```
+
+### 6.3 Cloud Run にデプロイ
+
+```bash
+gcloud run deploy fastapi-backend \
+  --image=${REGION}-docker.pkg.dev/${PROJECT_ID}/${AR_REPO}/fastapi-backend:v1 \
+  --region=$REGION \
+  --memory=512Mi \
+  --cpu=1 \
+  --min-instances=0 \
+  --max-instances=10 \
+  --port=8000 \
+  --ingress=all \
+  --allow-unauthenticated \
+  --set-secrets=SUPABASE_URL=SUPABASE_URL:latest,SUPABASE_KEY=SUPABASE_KEY:latest,JWT_SECRET=JWT_SECRET:latest,WEATHERAPI_KEY=WEATHERAPI_KEY:latest,GEMINI_API_KEY=GEMINI_API_KEY:latest,OTP2_GRAPHQL_URL=OTP2_GRAPHQL_URL:latest \
+  --service-account=fastapi-sa@${PROJECT_ID}.iam.gserviceaccount.com \
+  --timeout=60
+```
+
+### 6.4 デプロイ確認
+
+```bash
+# サービス情報の確認
+gcloud run services describe fastapi-backend --region=$REGION
+
+# URL の取得
+BACKEND_URL=$(gcloud run services describe fastapi-backend \
+  --region=$REGION --format='value(status.url)')
+echo "Backend URL: $BACKEND_URL"
+
+# ヘルスチェック
+curl -s ${BACKEND_URL}/health
+```
+
+---
+
+## 7. Cloud Run デプロイ: OTP2 Server
+
+### 7.1 前提: OTP2 データの準備
+
+OTP2 のデプロイには以下のファイルが `otp2/data/` に必要:
+
+- `graph.obj` — OTP2 のルーティンググラフ（~709MB）
+
+graph.obj の生成方法は `docs/research/api/外部経路探索API調査.md` を参照。
+
+```bash
+# data/ ディレクトリにファイルが存在するか確認
+ls -lh otp2/data/
+# graph.obj が存在すること
+```
+
+### 7.2 イメージのビルド＆プッシュ
+
+OTP2 のイメージは大きい (~1GB) ため、**Cloud Build でリモートビルド**を推奨。
+
+```bash
+# Cloud Build でリモートビルド（ローカルのファイルをアップロードしてビルド）
+gcloud builds submit ./otp2 \
+  --tag=${REGION}-docker.pkg.dev/${PROJECT_ID}/${AR_REPO}/otp2-server:v1 \
+  --timeout=1800s \
+  --machine-type=e2-highcpu-8
+```
+
+> **注意:**
+> - graph.obj (~709MB) のアップロードに時間がかかる
+> - `--timeout=1800s` で30分のタイムアウトを設定
+> - `--machine-type=e2-highcpu-8` でビルド高速化
+
+### 7.3 Cloud Run にデプロイ
+
+```bash
+gcloud run deploy otp2-server \
+  --image=${REGION}-docker.pkg.dev/${PROJECT_ID}/${AR_REPO}/otp2-server:v1 \
+  --region=$REGION \
+  --memory=4Gi \
+  --cpu=2 \
+  --min-instances=1 \
+  --max-instances=2 \
+  --port=8080 \
+  --ingress=internal \
+  --no-allow-unauthenticated \
+  --service-account=otp2-sa@${PROJECT_ID}.iam.gserviceaccount.com \
+  --timeout=300
+```
+
+### 7.4 デプロイ確認
+
+```bash
+# サービス情報の確認
+gcloud run services describe otp2-server --region=$REGION
+
+# 内部URLの取得
+OTP2_URL=$(gcloud run services describe otp2-server \
+  --region=$REGION --format='value(status.url)')
+echo "OTP2 Internal URL: $OTP2_URL"
+```
+
+> **注意:** OTP2 は `--ingress=internal` のため、外部からの curl テストは不可。
+> ヘルスチェックは Cloud Run の起動プローブで自動実行される。
+
+---
+
+## 8. サービス間通信の設定
+
+### 8.1 OTP2 の内部URLをシークレットに設定
+
+```bash
+# OTP2 の Cloud Run 内部URL を取得
+OTP2_URL=$(gcloud run services describe otp2-server \
+  --region=$REGION --format='value(status.url)')
+
+# Secret Manager の OTP2_GRAPHQL_URL を更新
+echo -n "${OTP2_URL}/otp/gtfs/v1" | \
+  gcloud secrets versions add OTP2_GRAPHQL_URL --data-file=-
+```
+
+### 8.2 FastAPI から OTP2 への呼び出し権限を付与
+
+```bash
+gcloud run services add-iam-policy-binding otp2-server \
+  --region=$REGION \
+  --member="serviceAccount:fastapi-sa@${PROJECT_ID}.iam.gserviceaccount.com" \
+  --role="roles/run.invoker"
+```
+
+### 8.3 FastAPI の再デプロイ（シークレット更新反映）
+
+```bash
+# 新しいリビジョンを作成してシークレットの最新バージョンを反映
+gcloud run services update fastapi-backend \
+  --region=$REGION \
+  --set-secrets=SUPABASE_URL=SUPABASE_URL:latest,SUPABASE_KEY=SUPABASE_KEY:latest,JWT_SECRET=JWT_SECRET:latest,WEATHERAPI_KEY=WEATHERAPI_KEY:latest,GEMINI_API_KEY=GEMINI_API_KEY:latest,OTP2_GRAPHQL_URL=OTP2_GRAPHQL_URL:latest
+```
+
+### 確認
+
+FastAPI から OTP2 への通信確認は、FastAPI の経路探索エンドポイントを呼び出して行う:
+
+```bash
+curl -s ${BACKEND_URL}/api/v1/routes \
+  -H "Authorization: Bearer YOUR_JWT_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"from": "...", "to": "..."}'
+```
+
+---
+
+## 9. Cloud Build CI/CD セットアップ
+
+### 9.1 GitHub リポジトリとの接続
+
+```bash
+# Cloud Build に GitHub アプリをインストール（初回のみ、ブラウザが開く）
+gcloud builds connections create github connection-github \
+  --region=$REGION
+```
+
+> **注意:** このコマンドでブラウザが開き、GitHub アプリのインストール・認可を求められる。
+
+```bash
+# リポジトリをリンク
+gcloud builds repositories create tenichi-hackathon-repo \
+  --remote-uri=https://github.com/YOUR_ORG/tenichi-hackathon.git \
+  --connection=connection-github \
+  --region=$REGION
+```
+
+### 9.2 Cloud Build トリガーの作成
+
+#### backend トリガー
+
+```bash
+gcloud builds triggers create github \
+  --name="deploy-fastapi-backend" \
+  --region=$REGION \
+  --repository=projects/${PROJECT_ID}/locations/${REGION}/connections/connection-github/repositories/tenichi-hackathon-repo \
+  --branch-pattern="^main$" \
+  --included-files="backend/**" \
+  --build-config="infra/cloudbuild-backend.yaml"
+```
+
+#### otp2 トリガー
+
+```bash
+gcloud builds triggers create github \
+  --name="deploy-otp2-server" \
+  --region=$REGION \
+  --repository=projects/${PROJECT_ID}/locations/${REGION}/connections/connection-github/repositories/tenichi-hackathon-repo \
+  --branch-pattern="^main$" \
+  --included-files="otp2/**" \
+  --build-config="infra/cloudbuild-otp2.yaml"
+```
+
+### 9.3 Cloud Build SA にシークレットアクセス権を付与
+
+Cloud Build がデプロイ時にシークレット参照を設定するため:
+
+```bash
+for SECRET in SUPABASE_URL SUPABASE_KEY JWT_SECRET WEATHERAPI_KEY GEMINI_API_KEY OTP2_GRAPHQL_URL; do
+  gcloud secrets add-iam-policy-binding $SECRET \
+    --member="serviceAccount:${PROJECT_NUMBER}@cloudbuild.gserviceaccount.com" \
+    --role="roles/secretmanager.secretAccessor"
+done
+```
+
+### 確認
+
+```bash
+# トリガー一覧
+gcloud builds triggers list --region=$REGION
+
+# 手動実行でテスト（backend）
+gcloud builds triggers run deploy-fastapi-backend \
+  --region=$REGION \
+  --branch=main
+```
+
+---
+
+## 10. ドメイン・SSL設定（オプション）
+
+カスタムドメインを使用する場合の手順。`*.run.app` のデフォルトURLで十分な場合はスキップ可。
+
+### 10.1 ドメインの所有権確認
+
+```bash
+gcloud domains verify YOUR_DOMAIN.com
+```
+
+### 10.2 Cloud Run にカスタムドメインをマッピング
+
+```bash
+gcloud run domain-mappings create \
+  --service=fastapi-backend \
+  --domain=api.YOUR_DOMAIN.com \
+  --region=$REGION
+```
+
+### 10.3 DNS設定
+
+Cloud Run が発行する DNS レコードを確認し、ドメインの DNS に設定:
+
+```bash
+gcloud run domain-mappings describe \
+  --domain=api.YOUR_DOMAIN.com \
+  --region=$REGION
+```
+
+出力された IP アドレスで DNS の A レコードを設定する。
+
+> **SSL証明書:** Cloud Run が自動でプロビジョニング・更新する。追加設定不要。
+
+---
+
+## 11. FCM プッシュ通知設定
+
+### 11.1 Firebase プロジェクトの作成
+
+GCP プロジェクトを Firebase に追加する:
+
+```bash
+# Firebase CLI のインストール
+npm install -g firebase-tools
+
+# Firebase にログイン
+firebase login
+
+# 既存の GCP プロジェクトを Firebase に追加
+firebase projects:addfirebase $PROJECT_ID
+```
+
+### 11.2 iOS アプリの登録
+
+Firebase Console (https://console.firebase.google.com/) で:
+
+1. 「プロジェクトの設定」→「アプリを追加」→「iOS」
+2. バンドルID を入力（例: `com.tenichi.app`）
+3. `GoogleService-Info.plist` をダウンロード
+4. iOS プロジェクトに追加
+
+### 11.3 APNs 認証キーの設定
+
+1. [Apple Developer Console](https://developer.apple.com/) で APNs 認証キー (.p8) を作成
+2. Firebase Console → 「プロジェクトの設定」→「Cloud Messaging」タブ
+3. 「APNs 認証キー」セクションで .p8 ファイルをアップロード
+4. Key ID と Team ID を入力
+
+### 11.4 バックエンドからの送信設定
+
+FastAPI から FCM を使用してプッシュ通知を送信するため、Application Default Credentials (ADC) を使用する。
+
+Cloud Run 上では ADC が自動で利用可能。追加のキー設定は不要。
+
+```bash
+# FastAPI のサービスアカウントに Firebase 送信権限を付与
+gcloud projects add-iam-policy-binding $PROJECT_ID \
+  --member="serviceAccount:fastapi-sa@${PROJECT_ID}.iam.gserviceaccount.com" \
+  --role="roles/firebase.sdkAdminServiceAgent"
+```
+
+---
+
+## 12. モニタリング・アラート設定
+
+### 12.1 Cloud Logging の確認
+
+ログは Cloud Run から自動収集される。確認方法:
+
+```bash
+# FastAPI のログを確認
+gcloud logging read "resource.type=cloud_run_revision AND resource.labels.service_name=fastapi-backend" \
+  --limit=20 \
+  --format="table(timestamp, textPayload)"
+
+# OTP2 のログを確認
+gcloud logging read "resource.type=cloud_run_revision AND resource.labels.service_name=otp2-server" \
+  --limit=20 \
+  --format="table(timestamp, textPayload)"
+```
+
+### 12.2 アラートポリシーの作成
+
+#### OTP2 メモリ使用率アラート
+
+```bash
+gcloud monitoring policies create \
+  --display-name="OTP2 Memory Usage > 80%" \
+  --condition-display-name="OTP2 Memory High" \
+  --condition-filter='resource.type="cloud_run_revision" AND resource.labels.service_name="otp2-server" AND metric.type="run.googleapis.com/container/memory/utilizations"' \
+  --condition-threshold-value=0.8 \
+  --condition-threshold-comparison=COMPARISON_GT \
+  --condition-threshold-duration=300s \
+  --notification-channels=CHANNEL_ID \
+  --combiner=OR
+```
+
+> **注意:** `CHANNEL_ID` は事前に通知チャネル（メール等）を作成して取得する。
+
+#### 通知チャネルの作成（メール）
+
+```bash
+gcloud monitoring channels create \
+  --display-name="Team Email" \
+  --type=email \
+  --channel-labels=email_address=team@example.com
+```
+
+### 12.3 ダッシュボード作成
+
+GCP Console で手動作成が推奨:
+
+1. [Cloud Monitoring](https://console.cloud.google.com/monitoring) を開く
+2. 「ダッシュボード」→「ダッシュボードを作成」
+3. 以下のウィジェットを追加:
+   - Cloud Run リクエスト数（fastapi-backend）
+   - Cloud Run レイテンシ p50/p95/p99（fastapi-backend）
+   - Cloud Run エラーレート（fastapi-backend）
+   - Cloud Run メモリ使用率（otp2-server）
+   - Cloud Run CPU使用率（otp2-server）
+   - Cloud Run インスタンス数（両サービス）
+
+---
+
+## 13. コスト管理
+
+### 13.1 予算アラートの設定
+
+```bash
+# 月額 $60 で予算アラートを設定（50%, 80%, 100% で通知）
+gcloud billing budgets create \
+  --billing-account=BILLING_ACCOUNT_ID \
+  --display-name="Tenichi Monthly Budget" \
+  --budget-amount=60USD \
+  --threshold-rules-percent=0.5,0.8,1.0 \
+  --all-updates-rule-monitoring-notification-channels=CHANNEL_ID
+```
+
+### 13.2 コスト見積もり
+
+| 項目 | 月額見積もり | 備考 |
+|------|------------|------|
+| Cloud Run (FastAPI) | ~$0 | 無料枠: 200万リクエスト/月 |
+| Cloud Run (OTP2, min=1) | ~$30-50 | 4GB RAM × 1インスタンス常時起動 |
+| Artifact Registry | ~$1 | ストレージ料金 |
+| Cloud Build | ~$0 | 無料枠: 120分/日 |
+| Secret Manager | ~$0 | 少数のシークレット |
+| Cloud Monitoring | ~$0 | 無料枠内 |
+| **合計** | **~$30-50/月** | |
+
+### 13.3 コスト削減のヒント
+
+- OTP2 の `--min-instances=0` に変更するとコールドスタートが発生するが、常時稼働コストを削減可能
+- 開発中は OTP2 の `--max-instances=1` に制限
+- Artifact Registry の古いイメージを定期削除
+
+---
+
+## 付録
+
+### 付録A: 環境変数一覧
+
+| 環境変数 | 対象サービス | 設定方法 | 説明 |
+|---------|------------|---------|------|
+| `SUPABASE_URL` | fastapi-backend | Secret Manager | Supabase 接続URL |
+| `SUPABASE_KEY` | fastapi-backend | Secret Manager | Supabase API キー |
+| `JWT_SECRET` | fastapi-backend | Secret Manager | JWT 署名キー |
+| `WEATHERAPI_KEY` | fastapi-backend | Secret Manager | WeatherAPI キー |
+| `GEMINI_API_KEY` | fastapi-backend | Secret Manager | Gemini API キー |
+| `OTP2_GRAPHQL_URL` | fastapi-backend | Secret Manager | OTP2 内部URL + パス |
+
+### 付録B: トラブルシューティング
+
+#### Cloud Run デプロイが失敗する
+
+```bash
+# ビルドログの確認
+gcloud builds list --limit=5
+gcloud builds log BUILD_ID
+```
+
+**よくある原因:**
+- Dockerfile の構文エラー
+- requirements.txt の依存関係解決失敗
+- Secret Manager へのアクセス権限不足
+
+#### OTP2 が起動しない
+
+```bash
+# Cloud Run のログを確認
+gcloud logging read "resource.labels.service_name=otp2-server" --limit=50
+```
+
+**よくある原因:**
+- `graph.obj` が `otp2/data/` に存在しない
+- メモリ不足（4GB で不足する場合は `--memory=6Gi` に増量）
+- Java ヒープサイズ不足（Dockerfile の `-Xmx3G` を調整）
+
+#### FastAPI から OTP2 に接続できない
+
+**確認手順:**
+1. OTP2 のサービスステータス確認: `gcloud run services describe otp2-server --region=$REGION`
+2. IAM 権限確認: `fastapi-sa` に `roles/run.invoker` が付与されているか
+3. `OTP2_GRAPHQL_URL` シークレットの値が正しい内部URLか確認
+4. FastAPI のコード側で ID Token を正しく取得しているか確認
+
+#### Cloud Build が失敗する
+
+```bash
+# 失敗したビルドの詳細
+gcloud builds describe BUILD_ID --region=$REGION
+```
+
+**よくある原因:**
+- GitHub 接続の認可が切れている
+- Artifact Registry への push 権限不足
+- タイムアウト（OTP2 の場合は `--timeout=1800s` を確認）
+
+### 付録C: クリーンアップ手順（リソース削除）
+
+プロジェクト全体を削除する場合:
+
+```bash
+# ⚠️ 注意: プロジェクト内の全リソースが削除される
+gcloud projects delete $PROJECT_ID
+```
+
+個別リソースの削除:
+
+```bash
+# Cloud Run サービス削除
+gcloud run services delete fastapi-backend --region=$REGION --quiet
+gcloud run services delete otp2-server --region=$REGION --quiet
+
+# Cloud Build トリガー削除
+gcloud builds triggers delete deploy-fastapi-backend --region=$REGION --quiet
+gcloud builds triggers delete deploy-otp2-server --region=$REGION --quiet
+
+# Artifact Registry リポジトリ削除
+gcloud artifacts repositories delete $AR_REPO --location=$REGION --quiet
+
+# Secret Manager シークレット削除
+for SECRET in SUPABASE_URL SUPABASE_KEY JWT_SECRET WEATHERAPI_KEY GEMINI_API_KEY OTP2_GRAPHQL_URL; do
+  gcloud secrets delete $SECRET --quiet
+done
+
+# サービスアカウント削除
+gcloud iam service-accounts delete fastapi-sa@${PROJECT_ID}.iam.gserviceaccount.com --quiet
+gcloud iam service-accounts delete otp2-sa@${PROJECT_ID}.iam.gserviceaccount.com --quiet
+```
+
+### 付録D: 構築チェックリスト
+
+| # | 手順 | 状態 |
+|---|------|------|
+| 1 | GCPプロジェクト作成 | ☐ |
+| 2 | 請求先アカウントリンク | ☐ |
+| 3 | API有効化 | ☐ |
+| 4 | サービスアカウント作成 (fastapi-sa, otp2-sa) | ☐ |
+| 5 | Cloud Build SA に権限付与 | ☐ |
+| 6 | Artifact Registry 作成 | ☐ |
+| 7 | Secret Manager にシークレット作成 (6個) | ☐ |
+| 8 | FastAPI Backend デプロイ | ☐ |
+| 9 | OTP2 Server デプロイ | ☐ |
+| 10 | OTP2 内部URL を Secret Manager に設定 | ☐ |
+| 11 | fastapi-sa に OTP2 invoker 権限付与 | ☐ |
+| 12 | FastAPI 再デプロイ（シークレット更新反映） | ☐ |
+| 13 | GitHub 接続 + Cloud Build トリガー作成 | ☐ |
+| 14 | Firebase プロジェクト追加 + APNs 設定 | ☐ |
+| 15 | モニタリング・アラート設定 | ☐ |
+| 16 | 予算アラート設定 | ☐ |
+| 17 | エンドツーエンドテスト | ☐ |

--- a/infra/docs/ネットワーク・セキュリティ設計.md
+++ b/infra/docs/ネットワーク・セキュリティ設計.md
@@ -1,0 +1,261 @@
+# ネットワーク・セキュリティ設計
+
+> **構成:** 案A — Cloud Run マルチサービス構成（確定）
+> **クライアント:** iOS アプリ（React Native）
+> **更新日:** 2026-03-05
+
+---
+
+## 1. ネットワーク構成
+
+### 全体像
+
+```
+Internet
+    │
+    ▼
+┌─────────────────────────────────────────┐
+│  Cloud Run: fastapi-backend             │
+│  --ingress all                          │
+│  --allow-unauthenticated                │
+│  URL: https://fastapi-backend-xxxxx-an.a.run.app │
+└──────────────┬──────────────────────────┘
+               │ Internal HTTP (IAM認証)
+               ▼
+┌─────────────────────────────────────────┐
+│  Cloud Run: otp2-server                 │
+│  --ingress internal                     │
+│  --no-allow-unauthenticated             │
+│  URL: https://otp2-server-xxxxx-an.a.run.app    │
+└─────────────────────────────────────────┘
+```
+
+### 公開エンドポイント
+
+| サービス | URL | アクセス元 | 認証方式 |
+|---------|-----|-----------|---------|
+| fastapi-backend | `*.run.app` or カスタムドメイン | iOS アプリ（Internet） | Supabase JWT (Bearer) |
+
+- `--ingress all`: インターネットからのアクセスを許可
+- `--allow-unauthenticated`: Cloud Run IAMレベルでは認証不要（アプリ層で認証）
+- HTTPS は Cloud Run が自動で提供（TLS終端）
+
+### 内部エンドポイント
+
+| サービス | URL | アクセス元 | 認証方式 |
+|---------|-----|-----------|---------|
+| otp2-server | `*.run.app`（内部URL） | fastapi-backend のみ | Cloud Run IAM (ID Token) |
+
+- `--ingress internal`: 同一GCPプロジェクト内のCloud Runサービスからのみアクセス可
+- `--no-allow-unauthenticated`: IAM認証必須
+- 外部（Internet）からは一切アクセス不可
+
+### VPC設定
+
+- **VPC Connectorは不要**
+- Cloud Run間の通信はサービスURL経由で行う（VPCネットワーク経由ではない）
+- OTP2への通信はCloud Run内部ルーティングで処理される
+
+---
+
+## 2. 認証・認可
+
+### 2.1 iOS App → FastAPI Backend
+
+```
+iOS App
+  │
+  │ Authorization: Bearer <Supabase JWT>
+  │
+  ▼
+FastAPI Backend
+  │
+  └─ JWT検証 (JWT_SECRET で署名検証)
+     ├─ 有効: リクエスト処理
+     └─ 無効: 401 Unauthorized
+```
+
+**認証フロー:**
+1. iOS アプリが Supabase Auth でログイン/登録
+2. Supabase が JWT を発行
+3. iOS アプリが全APIリクエストに `Authorization: Bearer <JWT>` ヘッダーを付与
+4. FastAPI が `JWT_SECRET` で署名を検証
+
+**認証不要のエンドポイント:**
+- `POST /api/v1/auth/register` — ユーザー登録
+- `POST /api/v1/auth/login` — ログイン
+- `GET /health` — ヘルスチェック
+
+### 2.2 FastAPI Backend → OTP2 Server
+
+```
+FastAPI Backend
+  │
+  │ Authorization: Bearer <GCP ID Token>
+  │ (サービスアカウントで自動取得)
+  │
+  ▼
+OTP2 Server (--no-allow-unauthenticated)
+```
+
+**認証フロー:**
+1. FastAPI が Google Auth ライブラリで ID Token を取得
+2. OTP2 の Cloud Run URL を audience として指定
+3. リクエストヘッダーに `Authorization: Bearer <ID Token>` を付与
+4. Cloud Run が自動で ID Token を検証
+
+**FastAPI側の実装例:**
+
+```python
+import google.auth.transport.requests
+import google.oauth2.id_token
+
+def get_otp2_id_token(otp2_url: str) -> str:
+    auth_req = google.auth.transport.requests.Request()
+    return google.oauth2.id_token.fetch_id_token(auth_req, otp2_url)
+```
+
+**IAM設定:**
+
+```bash
+# fastapi-backend のサービスアカウントに otp2-server の invoker 権限を付与
+gcloud run services add-iam-policy-binding otp2-server \
+  --region=asia-northeast1 \
+  --member="serviceAccount:fastapi-sa@PROJECT_ID.iam.gserviceaccount.com" \
+  --role="roles/run.invoker"
+```
+
+### 2.3 FastAPI Backend → Supabase
+
+- `SUPABASE_URL` + `SUPABASE_KEY` による API キー認証
+- HTTPS 通信（Supabase 側で TLS）
+- サービスロールキー使用（クライアントキーではない）
+
+### 2.4 FastAPI Backend → 外部API
+
+| API | 認証方式 | ヘッダー/パラメータ |
+|-----|---------|-------------------|
+| WeatherAPI.com | APIキー | `?key=WEATHERAPI_KEY` |
+| Google Gemini | APIキー | `x-goog-api-key: GEMINI_API_KEY` |
+| FCM | サービスアカウント | OAuth2 Bearer Token (ADC) |
+
+---
+
+## 3. シークレット管理
+
+### Cloud Secret Manager
+
+全シークレットは Cloud Secret Manager で管理し、Cloud Run に環境変数として注入する。
+
+| シークレット名 | 用途 | 参照元 |
+|---------------|------|--------|
+| `SUPABASE_URL` | Supabase 接続URL | fastapi-backend |
+| `SUPABASE_KEY` | Supabase API キー（サービスロール） | fastapi-backend |
+| `JWT_SECRET` | JWT 署名検証キー | fastapi-backend |
+| `WEATHERAPI_KEY` | WeatherAPI.com の API キー | fastapi-backend |
+| `GEMINI_API_KEY` | Google Gemini API キー | fastapi-backend |
+| `OTP2_GRAPHQL_URL` | OTP2 の内部 Cloud Run URL | fastapi-backend |
+
+### アクセス制御
+
+```bash
+# fastapi-backend のサービスアカウントにのみシークレット読み取りを許可
+gcloud secrets add-iam-policy-binding SECRET_NAME \
+  --member="serviceAccount:fastapi-sa@PROJECT_ID.iam.gserviceaccount.com" \
+  --role="roles/secretmanager.secretAccessor"
+```
+
+### ローテーションポリシー
+
+ハッカソン規模では自動ローテーションは不要。手動更新時の手順:
+
+1. 新しい値で Secret Manager のバージョンを追加
+2. Cloud Run サービスを再デプロイ（latest バージョンを自動参照）
+3. 古いバージョンを無効化
+
+---
+
+## 4. API セキュリティ
+
+### レート制限
+
+Cloud Run 自体にはレート制限機能がないため、アプリ層で実装する。
+
+**推奨: FastAPI ミドルウェア（slowapi）**
+
+```python
+from slowapi import Limiter
+from slowapi.util import get_remote_address
+
+limiter = Limiter(key_func=get_remote_address)
+
+@app.get("/api/v1/routes")
+@limiter.limit("30/minute")
+async def get_routes(request: Request):
+    ...
+```
+
+**将来的な選択肢（必要に応じて）:**
+- Cloud Armor: DDoS防御 + WAFルール（追加コストあり）
+- API Gateway: レート制限 + APIキー管理（追加コストあり）
+
+### CORS設定
+
+iOS アプリはネイティブ HTTP クライアント（URLSession / Axios via React Native）を使用するため、**CORS は原則不要**。
+
+ただし、開発時の Web デバッグツール使用を考慮し、開発環境ではワイルドカード許可も可:
+
+```python
+# 本番環境ではCORSミドルウェア不要
+# 開発環境のみ必要に応じて設定
+if settings.ENVIRONMENT == "development":
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=["*"],
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+```
+
+### 入力バリデーション
+
+- FastAPI の Pydantic モデルで自動バリデーション
+- リクエストボディ・クエリパラメータは型付きスキーマで検証
+- 不正な入力は 422 Unprocessable Entity で自動レスポンス
+
+### HTTPSの強制
+
+- Cloud Run はデフォルトで HTTPS を提供
+- HTTP リクエストは自動的に HTTPS にリダイレクト
+- 追加の TLS 設定は不要
+
+---
+
+## 5. IAM ポリシー一覧
+
+### サービスアカウント
+
+| サービスアカウント | 用途 |
+|-------------------|------|
+| `fastapi-sa@PROJECT_ID.iam.gserviceaccount.com` | FastAPI Backend 用 |
+| `otp2-sa@PROJECT_ID.iam.gserviceaccount.com` | OTP2 Server 用 |
+| `PROJECT_NUMBER@cloudbuild.gserviceaccount.com` | Cloud Build デフォルト SA |
+
+### ロール割り当て
+
+| サービスアカウント | ロール | 対象リソース | 目的 |
+|-------------------|--------|-------------|------|
+| fastapi-sa | `roles/secretmanager.secretAccessor` | 各シークレット | シークレット読み取り |
+| fastapi-sa | `roles/run.invoker` | otp2-server | OTP2 サービス呼び出し |
+| otp2-sa | （なし） | — | 外部アクセス不要 |
+| Cloud Build SA | `roles/run.admin` | Cloud Run | サービスデプロイ |
+| Cloud Build SA | `roles/iam.serviceAccountUser` | fastapi-sa, otp2-sa | SA としてデプロイ |
+| Cloud Build SA | `roles/artifactregistry.writer` | Artifact Registry | イメージ push |
+| Cloud Build SA | `roles/secretmanager.secretAccessor` | 各シークレット | ビルド時のシークレット参照 |
+
+### 最小権限の原則
+
+- 各サービスアカウントには必要最小限のロールのみ付与
+- `roles/editor` や `roles/owner` は使用しない
+- OTP2 サービスアカウントは外部アクセスが不要なため追加ロール不要
+- Cloud Build SA には Cloud Run デプロイに必要な権限のみ付与

--- a/infra/docs/運用・監視ガイド.md
+++ b/infra/docs/運用・監視ガイド.md
@@ -1,0 +1,328 @@
+# 運用・監視ガイド
+
+> **構成:** 案A — Cloud Run マルチサービス構成（確定）
+> **クライアント:** iOS アプリ（React Native）
+> **更新日:** 2026-03-05
+
+---
+
+## 1. Cloud Logging
+
+### 1.1 ログの確認方法
+
+#### GCP Console
+
+1. [Cloud Logging](https://console.cloud.google.com/logs/query) を開く
+2. リソースタイプ「Cloud Run Revision」を選択
+3. サービス名でフィルタ
+
+#### gcloud CLI
+
+```bash
+# FastAPI の直近ログ（20件）
+gcloud logging read \
+  'resource.type="cloud_run_revision" AND resource.labels.service_name="fastapi-backend"' \
+  --limit=20 \
+  --format="table(timestamp, severity, textPayload)"
+
+# OTP2 の直近ログ（20件）
+gcloud logging read \
+  'resource.type="cloud_run_revision" AND resource.labels.service_name="otp2-server"' \
+  --limit=20 \
+  --format="table(timestamp, severity, textPayload)"
+
+# エラーログのみ
+gcloud logging read \
+  'resource.type="cloud_run_revision" AND severity>=ERROR' \
+  --limit=20
+
+# 特定の時間範囲
+gcloud logging read \
+  'resource.type="cloud_run_revision" AND resource.labels.service_name="fastapi-backend" AND timestamp>="2026-03-05T00:00:00Z"' \
+  --limit=50
+```
+
+### 1.2 ログフィルタの書き方
+
+| フィルタ | 説明 |
+|---------|------|
+| `severity>=ERROR` | ERROR以上のログ |
+| `severity=WARNING` | WARNINGログのみ |
+| `textPayload:"timeout"` | "timeout" を含むログ |
+| `httpRequest.status>=500` | 5xx エラーのリクエスト |
+| `httpRequest.latency>"5s"` | レイテンシ5秒超のリクエスト |
+
+### 1.3 ログベースメトリクスの作成
+
+```bash
+# 5xx エラーのカウントメトリクス
+gcloud logging metrics create fastapi-5xx-errors \
+  --description="FastAPI 5xx error count" \
+  --log-filter='resource.type="cloud_run_revision" AND resource.labels.service_name="fastapi-backend" AND httpRequest.status>=500'
+```
+
+---
+
+## 2. Cloud Monitoring
+
+### 2.1 主要メトリクス
+
+Cloud Run が自動的に収集するメトリクス:
+
+| メトリクス | 説明 | 対象 |
+|-----------|------|------|
+| `run.googleapis.com/request_count` | リクエスト数 | 両サービス |
+| `run.googleapis.com/request_latencies` | レスポンスタイム | 両サービス |
+| `run.googleapis.com/container/cpu/utilizations` | CPU使用率 | 両サービス |
+| `run.googleapis.com/container/memory/utilizations` | メモリ使用率 | 両サービス |
+| `run.googleapis.com/container/instance_count` | インスタンス数 | 両サービス |
+| `run.googleapis.com/container/startup_latencies` | 起動レイテンシ | 両サービス |
+
+### 2.2 ダッシュボード設計
+
+推奨ダッシュボード構成:
+
+```
+┌──────────────────────────────────────────────────────┐
+│ Tenichi Infrastructure Dashboard                      │
+├──────────────────────┬───────────────────────────────┤
+│ FastAPI リクエスト数   │ FastAPI レイテンシ (p50/p95/p99) │
+├──────────────────────┼───────────────────────────────┤
+│ FastAPI エラーレート   │ FastAPI インスタンス数          │
+├──────────────────────┼───────────────────────────────┤
+│ OTP2 メモリ使用率     │ OTP2 CPU使用率                │
+├──────────────────────┼───────────────────────────────┤
+│ OTP2 レイテンシ       │ OTP2 インスタンス数            │
+└──────────────────────┴───────────────────────────────┘
+```
+
+GCP Console → Cloud Monitoring → ダッシュボード → 作成 で上記ウィジェットを追加する。
+
+---
+
+## 3. アラートポリシー
+
+### 3.1 推奨アラート
+
+| アラート名 | 条件 | 持続時間 | 重要度 |
+|-----------|------|---------|--------|
+| OTP2 Memory High | メモリ使用率 > 80% | 5分 | Critical |
+| FastAPI Error Rate | 5xx エラーレート > 5% | 5分 | Warning |
+| FastAPI Latency | p99 レイテンシ > 5秒 | 5分 | Warning |
+| OTP2 Instance Down | インスタンス数 < 1 | 1分 | Critical |
+
+### 3.2 通知チャネル設定
+
+```bash
+# メール通知チャネルの作成
+gcloud monitoring channels create \
+  --display-name="Team Email Notification" \
+  --type=email \
+  --channel-labels=email_address=your-team@example.com
+
+# チャネルIDの取得
+gcloud monitoring channels list --format="table(name, displayName)"
+```
+
+### 3.3 アラートポリシー作成（CLI）
+
+```bash
+# OTP2 メモリ使用率アラート
+gcloud monitoring policies create \
+  --display-name="OTP2 Memory Usage > 80%" \
+  --condition-display-name="OTP2 Memory High" \
+  --condition-filter='resource.type="cloud_run_revision" AND resource.labels.service_name="otp2-server" AND metric.type="run.googleapis.com/container/memory/utilizations"' \
+  --condition-threshold-value=0.8 \
+  --condition-threshold-comparison=COMPARISON_GT \
+  --condition-threshold-duration=300s \
+  --notification-channels=CHANNEL_ID \
+  --combiner=OR
+```
+
+> **推奨:** 複雑なアラートは GCP Console の GUI で作成する方が簡単。
+
+---
+
+## 4. ヘルスチェック
+
+### 4.1 FastAPI Backend
+
+| 項目 | 値 |
+|------|-----|
+| エンドポイント | `GET /health` |
+| 期待レスポンス | `200 OK` |
+| 実装必要 | はい（FastAPI に `/health` エンドポイントを追加） |
+
+**実装例:**
+
+```python
+@app.get("/health")
+async def health_check():
+    return {"status": "ok"}
+```
+
+### 4.2 OTP2 Server
+
+| 項目 | 値 |
+|------|-----|
+| エンドポイント | `GET /otp/actuators/health` |
+| 期待レスポンス | `200 OK` |
+| 実装必要 | いいえ（OTP2 標準機能） |
+| 起動待機時間 | ~120秒（グラフ読み込み） |
+
+Cloud Run のスタートアッププローブ設定:
+
+```bash
+# OTP2 の起動プローブを設定
+gcloud run services update otp2-server \
+  --region=asia-northeast1 \
+  --startup-cpu-boost \
+  --startup-probe-http-path=/otp/actuators/health \
+  --startup-probe-initial-delay=30 \
+  --startup-probe-period=10 \
+  --startup-probe-failure-threshold=12 \
+  --startup-probe-timeout=5
+```
+
+---
+
+## 5. インシデント対応
+
+### 5.1 OTP2 が OOMKilled された場合
+
+**症状:** OTP2 のログに `Container killed due to memory usage exceeding limit` が表示
+
+**対応:**
+
+```bash
+# 1. メモリ上限を確認
+gcloud run services describe otp2-server --region=asia-northeast1 \
+  --format='value(spec.template.spec.containers[0].resources.limits.memory)'
+
+# 2. メモリを増量（例: 4Gi → 6Gi）
+gcloud run services update otp2-server \
+  --region=asia-northeast1 \
+  --memory=6Gi
+
+# 3. Java ヒープサイズも調整が必要な場合
+# otp2/Dockerfile の CMD を変更: -Xmx3G → -Xmx5G
+```
+
+### 5.2 FastAPI がコールドスタートで遅い場合
+
+**症状:** 初回リクエストのレイテンシが数秒かかる
+
+**対応:**
+
+```bash
+# min-instances を 1 に変更（常時起動、コスト増加あり）
+gcloud run services update fastapi-backend \
+  --region=asia-northeast1 \
+  --min-instances=1
+```
+
+> **注意:** min-instances=1 にすると追加コスト（~$5-10/月）が発生する。
+
+### 5.3 Cloud Build が失敗した場合
+
+```bash
+# 1. 最近のビルド一覧
+gcloud builds list --limit=5 --region=asia-northeast1
+
+# 2. 失敗したビルドのログ
+gcloud builds log BUILD_ID --region=asia-northeast1
+
+# 3. 手動で再実行
+gcloud builds triggers run TRIGGER_NAME \
+  --region=asia-northeast1 \
+  --branch=main
+```
+
+**よくある原因と対策:**
+
+| 原因 | 対策 |
+|------|------|
+| Docker build エラー | Dockerfile を修正して再プッシュ |
+| Artifact Registry push 失敗 | IAM 権限を確認 |
+| Cloud Run deploy 失敗 | サービスの設定値（メモリ等）を確認 |
+| タイムアウト | cloudbuild YAML の timeout を増やす |
+
+### 5.4 サービス全体がダウンした場合
+
+```bash
+# 1. 全サービスのステータス確認
+gcloud run services list --region=asia-northeast1
+
+# 2. 各サービスの詳細確認
+gcloud run services describe fastapi-backend --region=asia-northeast1
+gcloud run services describe otp2-server --region=asia-northeast1
+
+# 3. 最新リビジョンの確認
+gcloud run revisions list --service=fastapi-backend --region=asia-northeast1
+
+# 4. 前のリビジョンにロールバック
+gcloud run services update-traffic fastapi-backend \
+  --region=asia-northeast1 \
+  --to-revisions=PREVIOUS_REVISION=100
+```
+
+---
+
+## 6. 定期メンテナンス
+
+### 6.1 OTP2 GTFS データ更新
+
+GTFS データの有効期限が切れた場合、graph.obj の再ビルドが必要。
+
+```bash
+# 1. 新しい GTFS データを取得・配置
+# （docs/research/api/外部経路探索API調査.md を参照）
+
+# 2. graph.obj を再ビルド
+java -Xmx4G -jar otp-2.7.0-shaded.jar --build --save otp2/data/
+
+# 3. OTP2 を再デプロイ
+gcloud builds submit ./otp2 \
+  --tag=asia-northeast1-docker.pkg.dev/PROJECT_ID/app/otp2-server:NEW_TAG \
+  --timeout=1800s
+
+gcloud run deploy otp2-server \
+  --image=asia-northeast1-docker.pkg.dev/PROJECT_ID/app/otp2-server:NEW_TAG \
+  --region=asia-northeast1
+```
+
+### 6.2 シークレットの更新
+
+```bash
+# 新しいバージョンを追加
+echo -n "new-value" | gcloud secrets versions add SECRET_NAME --data-file=-
+
+# Cloud Run は `latest` を参照しているため、サービス更新で反映
+gcloud run services update fastapi-backend --region=asia-northeast1
+```
+
+### 6.3 Artifact Registry の古いイメージ削除
+
+```bash
+# 30日以上前のイメージを一覧表示
+gcloud artifacts docker images list \
+  asia-northeast1-docker.pkg.dev/PROJECT_ID/app/fastapi-backend \
+  --filter="createTime<$(date -d '-30 days' --iso-8601=seconds)" \
+  --format="value(DIGEST)"
+
+# 手動削除
+gcloud artifacts docker images delete \
+  asia-northeast1-docker.pkg.dev/PROJECT_ID/app/fastapi-backend@sha256:DIGEST \
+  --quiet
+```
+
+### 6.4 コスト確認
+
+```bash
+# 月初からの請求額確認
+gcloud billing projects describe $PROJECT_ID
+
+# 詳細はGCP Console: https://console.cloud.google.com/billing
+```
+
+月1回のコスト確認を推奨。OTP2 の常時起動コスト (~$30-50) が主要な支出。


### PR DESCRIPTION
iOSアプリ(React Native)をクライアントとしたCloud Runマルチサービス構成の
詳細なインフラドキュメントを作成。Firebase Hostingを削除し、FastAPI Backend への直接HTTPS通信構成に変更。

- infra/docs/インフラ構築手順書.md: gcloudコマンド付きステップバイステップガイド
- infra/docs/アーキテクチャ図.md: Mermaid/ASCII図による確定アーキテクチャの視覚化
- infra/docs/ネットワーク・セキュリティ設計.md: 認証・認可・IAM設計
- infra/docs/CI-CDパイプライン設計.md: Cloud Buildトリガー・パイプライン設計
- infra/docs/運用・監視ガイド.md: ログ・アラート・インシデント対応
- infra/cloudbuild-backend.yaml: FastAPI用Cloud Build構成
- infra/cloudbuild-otp2.yaml: OTP2用Cloud Build構成

https://claude.ai/code/session_018EJ7LyfBmsidSqFvckQ6P6