### PR TITLE
docs: GCP Cloud Run確定を反映して開発タスクを全面改訂

### DIFF
--- a/backend/docs/tasks/開発タスク.md
+++ b/backend/docs/tasks/開発タスク.md
@@ -1,7 +1,7 @@
 # バックエンド 開発スケジュール
 
 > **担当:** バックエンド 1人（Python / FastAPI / PostgreSQL）
-> **進め方:** フェーズ順に進む。Phase 0 の意思決定が終わらないと後続フェーズのスキーマが確定しないため、最優先で潰す。
+> **進め方:** フェーズ順に進む。Phase 0 の意思決定は完了済み。Phase 1（インフラ）と Phase 2（基盤構築）を並行して進める。
 
 ---
 
@@ -45,35 +45,64 @@
 
 ### 外部API
 
-- [x] 🟡 **Routes** 経路 API を選定する（Google Directions API / Yahoo! 乗換 API 等）— **OTP2**（確定。GTFS・グラフビルド済み。デプロイ先は Phase 7 直前に決定）
+- [x] 🟡 **Routes** 経路 API を選定する（Google Directions API / Yahoo! 乗換 API 等）— **OTP2**（確定。GTFS・グラフビルド済み。）
 - [x] 🟢 **Suggestions** 提案ロジックのアプローチを決定する — **Gemini API を使って実装（確定）**
-- [ ] 🟢 **Infra-OTP2** OTP2 デプロイ先を確定する（`docs/research/インフラアーキテクチャ比較.md § 8` 参照）
-  - 推奨順: Plan D（AWS Lightsail $24/月）> Plan B（fly.io $30/月）> Plan A（GCE $36/月）
-- [ ] 🟢 **Infra-HERE** HERE Routing API の代替検証（OTP2 を $0 に置き換えられるか）
-  - 検証内容: API キー発行 → 東京区間で transit + arrivalTime クエリ → 経路精度確認
-  - 成功条件: OTP2 と同等の到着時刻逆算（逆方向探索）が動作すること
-  - 参考: `docs/research/インフラアーキテクチャ比較.md § HERE Routing API`
-  - 優先度: 低（$24/月を許容できるなら不要。節約したい場合のみ実施）
+- [x] 🟢 **Infra-OTP2** OTP2 デプロイ先を確定する — **GCP Cloud Run マルチサービス構成（案A）確定**
+      `infra/docs/` に設計書・構築手順書・CI/CDパイプライン設計を追加済み
 
 ---
 
-## Phase 1: 基盤構築
+## Phase 1: インフラ構築（GCP セットアップ）
+
+> 詳細手順: `infra/docs/インフラ構築手順書.md`
+> Phase 2（backend 実装）と並行して進める。初回デプロイに必要な最小セット（§1〜8）を優先。
+> 1人体制なら順番に、複数人なら並行実施可能。
+
+### GCP初期セットアップ（初回のみ）
+
+- [ ] 🔴 GCPプロジェクト作成・請求先リンク・デフォルトリージョン設定（§1）
+- [ ] 🔴 必要なAPI有効化（Cloud Run / Cloud Build / Artifact Registry / Secret Manager 等）（§2）
+- [ ] 🔴 サービスアカウント作成（fastapi-sa, otp2-sa）+ Cloud Build SAへの権限付与（§3）
+- [ ] 🔴 Artifact Registry Docker リポジトリ作成（§4）
+- [ ] 🔴 Secret Manager にシークレット作成（6個）・fastapi-sa にアクセス権付与（§5）
+
+### デプロイ（backend実装後）
+
+- [ ] 🔴 FastAPI Backend の初回デプロイ（§6）
+- [ ] 🔴 OTP2 Server の初回デプロイ（§7）
+- [ ] 🔴 OTP2 内部URL を Secret Manager に設定 + fastapi-sa に invoker 権限付与（§8）
+- [ ] 🟡 Cloud Build CI/CDトリガー作成（GitHub接続 + backend/otp2トリガー）（§9）
+
+### その他（ハッカソン後半）
+
+- [ ] 🟡 Firebase プロジェクト追加 + iOS APNs設定（§11）
+- [ ] 🟡 モニタリング・アラート設定（OTP2メモリ80%超アラート等）（§12）
+- [ ] 🟢 予算アラート設定（$60/月）（§13）
+
+---
+
+## Phase 2: 基盤構築
 
 > FastAPI / DB / マイグレーション / 共通ミドルウェアのセットアップ
 
 - [ ] 🔴 FastAPI プロジェクトのディレクトリ構成を決めて作成する
 - [ ] 🔴 依存パッケージを定義する（`pyproject.toml` / `requirements.txt`）
+      追加必須: `google-auth`, `google-auth-httplib2`（OTP2 IAM認証用）
 - [ ] 🔴 環境変数管理を実装する（`.env` / `pydantic-settings`）
 - [ ] 🔴 PostgreSQL 接続設定を実装する（SQLAlchemy async + asyncpg）
 - [ ] 🔴 Alembic マイグレーションの初期設定をする
-- [ ] 🟡 Docker / docker-compose 設定をする（DB + API）
+- [ ] 🔴 Dockerfile を作成する（FastAPI Backend 用 — Cloud Run デプロイに必須）
+      参照: `infra/docs/CI-CDパイプライン設計.md § 3`（cloudbuild-backend.yaml）
+      ポート 8000、依存関係レイヤーキャッシュ最適化
+- [ ] 🟡 docker-compose を作成する（ローカル開発用: PostgreSQL + FastAPI）
 - [ ] 🟡 共通エラーレスポンス形式を実装する（`backend/docs/spec/API詳細設計.md § エラーレスポンス` 準拠）
-- [ ] 🟡 CORS ミドルウェアを設定する
 - [ ] 🟡 ヘルスチェックエンドポイントを実装する（`GET /healthz`）
+- [ ] 🟢 CORS ミドルウェアを設定する（iOS本番は不要。ローカル開発時のみ検討）
+      参照: `infra/docs/ネットワーク・セキュリティ設計.md § 4`
 
 ---
 
-## Phase 2: 認証 (Auth)
+## Phase 3: 認証 (Auth)
 
 > Phase 0 の E-1（認証方式）確定後に着手
 
@@ -89,7 +118,7 @@
 
 ---
 
-## Phase 3: ユーザー (Users)
+## Phase 4: ユーザー (Users)
 
 > Phase 0 の D-1（UserSettings 初期作成タイミング）確定後に着手
 
@@ -101,7 +130,7 @@
 
 ---
 
-## Phase 4: コアAPI (Tags / Schedules / Templates)
+## Phase 5: コアAPI (Tags / Schedules / Templates)
 
 > Phase 0 の A-1・A-2・B-1（タグスコープ/作成権限、travel_mode ENUM）確定後に着手
 
@@ -134,7 +163,7 @@
 
 ---
 
-## Phase 5: 外部API連携 — 天気 (Weather)
+## Phase 6: 外部API連携 — 天気 (Weather)
 
 > WeatherAPI.com を使用（`backend/docs/spec/API詳細設計.md § Weather` 参照）
 
@@ -145,7 +174,7 @@
 
 ---
 
-## Phase 6: 通知設定 (Notifications)
+## Phase 7: 通知設定 (Notifications)
 
 > Phase 0 の D-1（NotificationSettings 初期作成タイミング）確定後に着手
 
@@ -158,17 +187,20 @@
 
 ---
 
-## Phase 7: 経路API (Routes) ← ブロッカー待ち
+## Phase 8: 経路API (Routes)
 
-> Phase 0 の Routes（経路 API 選定）が完了するまで着手不可
-> 詳細は `backend/docs/spec/API詳細設計.md § Routes` 参照
+> OTP2 on Cloud Run（案A）確定済み。インフラ構築（Phase 1 §7〜8）後に着手可能。
+> 詳細: `backend/docs/spec/経路探索API設計.md`
 
-- [ ] 🟢 外部経路 API クライアントを実装する（API 選定後）
-- [ ] 🟢 `POST /routes/departure-time` を実装する
+- [ ] 🟡 OTP2 GraphQL クライアントを実装する（HTTPx + Google ID Token 認証）
+      実装パターン: `infra/docs/ネットワーク・セキュリティ設計.md § 2.2`
+      `google.oauth2.id_token.fetch_id_token()` で `OTP2_GRAPHQL_URL` を audience に指定
+- [ ] 🟡 `POST /routes/departure-time` を実装する（OTP2 planConnection クエリ）
+      クエリ設計: `backend/docs/spec/経路探索API設計.md § 4.1`
 
 ---
 
-## Phase 8: 提案 (Suggestions) ← Gemini API を使って実装（確定）
+## Phase 9: 提案 (Suggestions)
 
 > **ブロッカー解消済み。** Gemini API を使った AI 提案として設計確定。
 > 詳細は `backend/docs/spec/API詳細設計.md § Suggestions` 参照
@@ -180,9 +212,9 @@
 
 ---
 
-## Phase 9: テスト・品質
+## Phase 10: テスト・品質
 
-> Phase 4 完了後から並行して進めることを推奨
+> Phase 5 完了後から並行して進めることを推奨
 
 - [ ] 🟡 pytest セットアップをする（テスト用 DB 設定含む）
 - [ ] 🟡 リンター / フォーマッターを設定する（ruff / black）
@@ -193,3 +225,29 @@
 - [ ] 🟢 Weather API のテストを書く（外部 API モックを使用）
 - [ ] 🟢 テストカバレッジを計測する（目標: コアAPI 80% 以上）
 - [ ] 🟢 CI（GitHub Actions）を設定する（lint + test の自動実行）
+
+---
+
+## 全体の着手優先順（クリティカルパス）
+
+```
+Week 1（今すぐ）
+  ├── Infra: GCPプロジェクト・API・SA・AR・Secrets（Phase 1 §1〜5）
+  └── Backend: Phase 2（基盤構築）+ Dockerfile
+
+Week 1-2
+  Backend: Phase 3（Auth）→ Phase 4（Users）→ Phase 5（Tags / Schedules）
+  Infra: FastAPI 初回デプロイ（Phase 1 §6）
+
+Week 2
+  Backend: Phase 6（Weather）→ Phase 7（Notifications）→ Phase 8（Routes）
+  Infra: OTP2 デプロイ → CI/CD トリガー（Phase 1 §7〜9）
+
+Week 3
+  Backend: Phase 9（Suggestions）
+  Infra: Firebase + APNs（Phase 1 §11）
+  Backend: Phase 10（テスト・品質）並行開始
+
+デモ直前
+  エンドツーエンドテスト（infra/docs/インフラ構築手順書.md 付録D チェックリスト）
+```


### PR DESCRIPTION
## Summary

GCP Cloud Run マルチサービス構成（案A）の確定と `infra/docs/` への設計書追加を受けて、`backend/docs/tasks/開発タスク.md` を全面見直し。

### 変更内容

- **Phase 0**: `Infra-OTP2` を確定済み（GCP Cloud Run 案A）に更新、`Infra-HERE` を削除（不要になったため）
- **Phase 1（新設）**: GCPインフラ構築タスクを追加
  - GCP初期セットアップ（§1〜5）
  - デプロイ（§6〜9）
  - その他・ハッカソン後半（§11〜13）
- **旧Phase 1 → Phase 2（基盤構築）**
  - `Dockerfile` を 🟡→🔴 に格上げ（Cloud Run デプロイの必須条件）
  - `docker-compose` は 🟡 で残す（ローカル開発用）
  - `google-auth`, `google-auth-httplib2` を依存パッケージに追記（OTP2 IAM認証用）
  - CORS を 🟡→🟢 に格下げ + 注記追加（iOS本番は不要）
- **旧Phase 2-9 → Phase 3-10**: フェーズ番号を全体シフト
- **旧Phase 7（Routes）→ Phase 8**: ブロッカー注記を削除（OTP2確定で解除）、優先度を 🟢→🟡 に格上げ、OTP2 IAM認証実装タスクを追加
- **クリティカルパス追加**: Week 1-3 + デモ直前の着手順を末尾に記載

### 参照ドキュメント

- `infra/docs/インフラ構築手順書.md`
- `infra/docs/ネットワーク・セキュリティ設計.md`
- `infra/docs/CI-CDパイプライン設計.md`

## Test plan

- [x] Phase 0 に未チェックの 🔴/🟡 タスクが残っていないこと
- [x] Phase 1〜10 のフェーズ番号が正しく連番になっていること
- [x] `Infra-HERE` の記述が削除されていること
- [x] Phase 8（Routes）にブロッカー注記がなく、IAM認証実装タスクが追加されていること
- [x] `google-auth` が Phase 2 の依存パッケージに記載されていること
- [x] CORS が 🟢 かつ iOS 本番不要の注記があること

🤖 Generated with [Claude Code](https://claude.com/claude-code)