### PR TITLE
feat: Phase 4 — ユーザー API 実装

### DIFF
--- a/backend/app/api/users.py
+++ b/backend/app/api/users.py
@@ -1,0 +1,51 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import get_db
+from app.dependencies.auth import get_current_user
+from app.models.user import User
+from app.schemas.users import (
+    UserProfileResponse,
+    UserProfileUpdate,
+    UserSettingsResponse,
+    UserSettingsUpdate,
+)
+from app.services import users_service
+
+router = APIRouter(prefix="/users", tags=["users"])
+
+
+@router.get("/me", response_model=UserProfileResponse)
+async def get_profile(
+    current_user: User = Depends(get_current_user),
+):
+    return current_user
+
+
+@router.put("/me", response_model=UserProfileResponse)
+async def update_profile(
+    data: UserProfileUpdate,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    user = await users_service.update_profile(db, current_user, data)
+    return user
+
+
+@router.get("/me/settings", response_model=UserSettingsResponse)
+async def get_settings(
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    settings = await users_service.get_settings(db, current_user.id)
+    return settings
+
+
+@router.put("/me/settings", response_model=UserSettingsResponse)
+async def update_settings(
+    data: UserSettingsUpdate,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    settings = await users_service.update_settings(db, current_user.id, data)
+    return settings

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,6 +4,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from app.api.auth import router as auth_router
 from app.api.healthz import router as healthz_router
+from app.api.users import router as users_router
 from app.config import settings
 from app.exceptions import (
     AppError,
@@ -29,3 +30,4 @@ app.add_exception_handler(Exception, generic_error_handler)
 
 app.include_router(healthz_router)
 app.include_router(auth_router, prefix="/api/v1")
+app.include_router(users_router, prefix="/api/v1")

--- a/backend/app/schemas/users.py
+++ b/backend/app/schemas/users.py
@@ -1,0 +1,37 @@
+from datetime import datetime
+from decimal import Decimal
+
+from pydantic import BaseModel
+
+
+class UserProfileResponse(BaseModel):
+    id: int
+    email: str
+    name: str
+    created_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class UserProfileUpdate(BaseModel):
+    name: str | None = None
+
+
+class UserSettingsResponse(BaseModel):
+    home_address: str
+    home_lat: Decimal | None
+    home_lon: Decimal | None
+    preparation_minutes: int
+    reminder_minutes_before: int
+    timezone: str
+
+    model_config = {"from_attributes": True}
+
+
+class UserSettingsUpdate(BaseModel):
+    home_address: str | None = None
+    home_lat: Decimal | None = None
+    home_lon: Decimal | None = None
+    preparation_minutes: int | None = None
+    reminder_minutes_before: int | None = None
+    timezone: str | None = None

--- a/backend/app/services/users_service.py
+++ b/backend/app/services/users_service.py
@@ -1,0 +1,42 @@
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.exceptions import AppError
+from app.models.user import User, UserSettings
+from app.schemas.users import UserProfileUpdate, UserSettingsUpdate
+
+
+async def update_profile(db: AsyncSession, user: User, data: UserProfileUpdate) -> User:
+    update_data = data.model_dump(exclude_unset=True)
+    if not update_data:
+        return user
+
+    for key, value in update_data.items():
+        setattr(user, key, value)
+
+    await db.commit()
+    await db.refresh(user)
+    return user
+
+
+async def get_settings(db: AsyncSession, user_id: int) -> UserSettings:
+    result = await db.execute(select(UserSettings).where(UserSettings.user_id == user_id))
+    settings = result.scalar_one_or_none()
+    if settings is None:
+        raise AppError("NOT_FOUND", "Settings not found", 404)
+    return settings
+
+
+async def update_settings(db: AsyncSession, user_id: int, data: UserSettingsUpdate) -> UserSettings:
+    settings = await get_settings(db, user_id)
+
+    update_data = data.model_dump(exclude_unset=True)
+    if not update_data:
+        return settings
+
+    for key, value in update_data.items():
+        setattr(settings, key, value)
+
+    await db.commit()
+    await db.refresh(settings)
+    return settings

--- a/backend/tests/test_api_users.py
+++ b/backend/tests/test_api_users.py
@@ -1,0 +1,114 @@
+"""users API エンドポイントの統合テスト."""
+
+import pytest
+
+REGISTER_DATA = {
+    "email": "user@example.com",
+    "password": "password123",
+    "name": "Test User",
+    "home_address": "東京都渋谷区",
+    "home_lat": 35.6584,
+    "home_lon": 139.7015,
+    "preparation_minutes": 30,
+    "reminder_minutes_before": 15,
+}
+
+
+async def _register_and_get_token(client) -> str:
+    response = await client.post("/api/v1/auth/register", json=REGISTER_DATA)
+    return response.json()["access_token"]
+
+
+def _auth_headers(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.mark.asyncio
+class TestGetProfile:
+    async def test_get_profile_success(self, client):
+        token = await _register_and_get_token(client)
+        response = await client.get("/api/v1/users/me", headers=_auth_headers(token))
+        assert response.status_code == 200
+        data = response.json()
+        assert data["email"] == "user@example.com"
+        assert data["name"] == "Test User"
+        assert "id" in data
+        assert "created_at" in data
+
+    async def test_get_profile_without_token(self, client):
+        response = await client.get("/api/v1/users/me")
+        assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+class TestUpdateProfile:
+    async def test_update_name(self, client):
+        token = await _register_and_get_token(client)
+        response = await client.put(
+            "/api/v1/users/me",
+            headers=_auth_headers(token),
+            json={"name": "Updated Name"},
+        )
+        assert response.status_code == 200
+        assert response.json()["name"] == "Updated Name"
+
+    async def test_update_empty_body(self, client):
+        token = await _register_and_get_token(client)
+        response = await client.put(
+            "/api/v1/users/me",
+            headers=_auth_headers(token),
+            json={},
+        )
+        assert response.status_code == 200
+        assert response.json()["name"] == "Test User"
+
+    async def test_update_without_token(self, client):
+        response = await client.put("/api/v1/users/me", json={"name": "X"})
+        assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+class TestGetSettings:
+    async def test_get_settings_success(self, client):
+        token = await _register_and_get_token(client)
+        response = await client.get("/api/v1/users/me/settings", headers=_auth_headers(token))
+        assert response.status_code == 200
+        data = response.json()
+        assert data["home_address"] == "東京都渋谷区"
+        assert data["preparation_minutes"] == 30
+        assert data["reminder_minutes_before"] == 15
+        assert data["timezone"] == "Asia/Tokyo"
+
+    async def test_get_settings_without_token(self, client):
+        response = await client.get("/api/v1/users/me/settings")
+        assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+class TestUpdateSettings:
+    async def test_update_partial(self, client):
+        token = await _register_and_get_token(client)
+        response = await client.put(
+            "/api/v1/users/me/settings",
+            headers=_auth_headers(token),
+            json={"preparation_minutes": 45, "home_address": "東京都新宿区"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["preparation_minutes"] == 45
+        assert data["home_address"] == "東京都新宿区"
+        assert data["reminder_minutes_before"] == 15  # unchanged
+
+    async def test_update_empty_body(self, client):
+        token = await _register_and_get_token(client)
+        response = await client.put(
+            "/api/v1/users/me/settings",
+            headers=_auth_headers(token),
+            json={},
+        )
+        assert response.status_code == 200
+        assert response.json()["preparation_minutes"] == 30
+
+    async def test_update_without_token(self, client):
+        response = await client.put("/api/v1/users/me/settings", json={"preparation_minutes": 10})
+        assert response.status_code == 403


### PR DESCRIPTION
## Summary
- `GET /users/me` / `PUT /users/me` — プロフィール取得・更新
- `GET /users/me/settings` / `PUT /users/me/settings` — 個人設定取得・部分更新
- スキーマ・サービス層・ルーター・テスト10ケース追加

## Test plan
- [x] `ruff check .` / `ruff format --check .` パス
- [x] `pytest tests/ -v` 全42テスト合格（既存32 + 新規10）
- [x] CI (GitHub Actions) グリーン確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)