### PR TITLE
feat: Phase 5 — コアAPI (Tags / Schedules / Templates / ScheduleLists) 実装

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -14,6 +14,21 @@ jobs:
       run:
         working-directory: backend
 
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: tenichi
+          POSTGRES_PASSWORD: tenichi
+          POSTGRES_DB: tenichi_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
     steps:
       - uses: actions/checkout@v4
 
@@ -47,6 +62,6 @@ jobs:
         run: pytest tests/ -v
         env:
           ENVIRONMENT: test
-          DATABASE_URL: sqlite+aiosqlite:///test.db
+          DATABASE_URL: postgresql+asyncpg://tenichi:tenichi@localhost:5432/tenichi_test
           JWT_SECRET: test-secret-key
           OTP2_GRAPHQL_URL: http://localhost:8080/otp/gtfs/v1

--- a/backend/alembic/versions/a1b2c3d4e5f6_create_phase5_core_tables.py
+++ b/backend/alembic/versions/a1b2c3d4e5f6_create_phase5_core_tables.py
@@ -1,0 +1,173 @@
+"""create phase5 core tables
+
+Revision ID: a1b2c3d4e5f6
+Revises: 713f37f71e12
+Create Date: 2026-03-06 20:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "a1b2c3d4e5f6"
+down_revision: Union[str, None] = "713f37f71e12"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Tags (global, seeded)
+    op.create_table(
+        "tags",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("name", sa.String(length=50), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("name"),
+    )
+
+    # Template categories (global, seeded)
+    op.create_table(
+        "template_categories",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("name", sa.String(length=50), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("name"),
+    )
+
+    # Schedule lists
+    op.create_table(
+        "schedule_lists",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("user_id", sa.BigInteger(), nullable=False),
+        sa.Column("name", sa.String(length=100), nullable=False),
+        sa.Column("date", sa.Date(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    # Schedules
+    op.create_table(
+        "schedules",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("user_id", sa.BigInteger(), nullable=False),
+        sa.Column("schedule_list_id", sa.BigInteger(), nullable=True),
+        sa.Column("title", sa.String(length=255), nullable=False),
+        sa.Column("start_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("end_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("destination_name", sa.String(length=255), nullable=True),
+        sa.Column("destination_address", sa.String(length=255), nullable=True),
+        sa.Column("destination_lat", sa.Numeric(precision=9, scale=6), nullable=True),
+        sa.Column("destination_lon", sa.Numeric(precision=9, scale=6), nullable=True),
+        sa.Column("travel_mode", sa.String(length=20), nullable=True),
+        sa.Column("memo", sa.Text(), nullable=True),
+        sa.Column("recurrence_rule", sa.String(length=500), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["schedule_list_id"], ["schedule_lists.id"], ondelete="SET NULL"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    # Schedule tags (junction)
+    op.create_table(
+        "schedule_tags",
+        sa.Column("schedule_id", sa.BigInteger(), nullable=False),
+        sa.Column("tag_id", sa.BigInteger(), nullable=False),
+        sa.ForeignKeyConstraint(["schedule_id"], ["schedules.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["tag_id"], ["tags.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("schedule_id", "tag_id"),
+    )
+
+    # Templates
+    op.create_table(
+        "templates",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("user_id", sa.BigInteger(), nullable=False),
+        sa.Column("name", sa.String(length=100), nullable=False),
+        sa.Column("template_category_id", sa.BigInteger(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["template_category_id"], ["template_categories.id"], ondelete="SET NULL"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    # Template schedules
+    op.create_table(
+        "template_schedules",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("template_id", sa.BigInteger(), nullable=False),
+        sa.Column("title", sa.String(length=255), nullable=False),
+        sa.Column("start_time", sa.Time(), nullable=False),
+        sa.Column("end_time", sa.Time(), nullable=True),
+        sa.Column("destination_name", sa.String(length=255), nullable=True),
+        sa.Column("destination_address", sa.String(length=255), nullable=True),
+        sa.Column("destination_lat", sa.Numeric(precision=9, scale=6), nullable=True),
+        sa.Column("destination_lon", sa.Numeric(precision=9, scale=6), nullable=True),
+        sa.Column("travel_mode", sa.String(length=20), nullable=True),
+        sa.Column("memo", sa.Text(), nullable=True),
+        sa.Column("sort_order", sa.Integer(), server_default="0", nullable=False),
+        sa.ForeignKeyConstraint(["template_id"], ["templates.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    # Template schedule tags (junction)
+    op.create_table(
+        "template_schedule_tags",
+        sa.Column("template_schedule_id", sa.BigInteger(), nullable=False),
+        sa.Column("tag_id", sa.BigInteger(), nullable=False),
+        sa.ForeignKeyConstraint(["template_schedule_id"], ["template_schedules.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["tag_id"], ["tags.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("template_schedule_id", "tag_id"),
+    )
+
+    # Packing items
+    op.create_table(
+        "packing_items",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("schedule_list_id", sa.BigInteger(), nullable=False),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("is_checked", sa.Boolean(), server_default="false", nullable=False),
+        sa.Column("sort_order", sa.Integer(), server_default="0", nullable=False),
+        sa.ForeignKeyConstraint(["schedule_list_id"], ["schedule_lists.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    # Schedule routes
+    op.create_table(
+        "schedule_routes",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("schedule_id", sa.BigInteger(), nullable=False),
+        sa.Column("route_data", sa.Text(), nullable=False),
+        sa.Column("departure_time", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("arrival_time", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("duration_minutes", sa.Integer(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.ForeignKeyConstraint(["schedule_id"], ["schedules.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("schedule_id"),
+    )
+
+    # Seed tags
+    op.execute("INSERT INTO tags (name) VALUES ('仕事'), ('会食'), ('デート'), ('運動')")
+
+    # Seed template categories
+    op.execute("INSERT INTO template_categories (name) VALUES ('仕事の日'), ('在宅勤務'), ('休日')")
+
+
+def downgrade() -> None:
+    op.drop_table("schedule_routes")
+    op.drop_table("packing_items")
+    op.drop_table("template_schedule_tags")
+    op.drop_table("template_schedules")
+    op.drop_table("templates")
+    op.drop_table("schedule_tags")
+    op.drop_table("schedules")
+    op.drop_table("schedule_lists")
+    op.drop_table("template_categories")
+    op.drop_table("tags")

--- a/backend/app/api/schedule_lists.py
+++ b/backend/app/api/schedule_lists.py
@@ -1,0 +1,102 @@
+import datetime as dt
+
+from fastapi import APIRouter, Depends, Query, Response
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import get_db
+from app.dependencies.auth import get_current_user
+from app.models.user import User
+from app.schemas.schedule_lists import (
+    PackingItemCreate,
+    PackingItemResponse,
+    PackingItemUpdate,
+    ScheduleListCreate,
+    ScheduleListResponse,
+    ScheduleListUpdate,
+)
+from app.services import schedule_lists_service
+
+router = APIRouter(prefix="/schedule-lists", tags=["schedule-lists"])
+
+
+@router.get("", response_model=list[ScheduleListResponse])
+async def list_schedule_lists(
+    start_date: dt.date | None = Query(None),
+    end_date: dt.date | None = Query(None),
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    return await schedule_lists_service.list_schedule_lists(db, current_user.id, start_date, end_date)
+
+
+@router.post("", response_model=ScheduleListResponse, status_code=201)
+async def create_schedule_list(
+    data: ScheduleListCreate,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    return await schedule_lists_service.create_schedule_list(db, current_user.id, data)
+
+
+@router.get("/{list_id}", response_model=ScheduleListResponse)
+async def get_schedule_list(
+    list_id: int,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    return await schedule_lists_service.get_schedule_list(db, current_user.id, list_id)
+
+
+@router.put("/{list_id}", response_model=ScheduleListResponse)
+async def update_schedule_list(
+    list_id: int,
+    data: ScheduleListUpdate,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    return await schedule_lists_service.update_schedule_list(db, current_user.id, list_id, data)
+
+
+@router.delete("/{list_id}", status_code=204)
+async def delete_schedule_list(
+    list_id: int,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    await schedule_lists_service.delete_schedule_list(db, current_user.id, list_id)
+    return Response(status_code=204)
+
+
+# --- Packing Items ---
+
+
+@router.post("/{list_id}/packing-items", response_model=PackingItemResponse, status_code=201)
+async def create_packing_item(
+    list_id: int,
+    data: PackingItemCreate,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    return await schedule_lists_service.create_packing_item(db, current_user.id, list_id, data)
+
+
+@router.put("/{list_id}/packing-items/{item_id}", response_model=PackingItemResponse)
+async def update_packing_item(
+    list_id: int,
+    item_id: int,
+    data: PackingItemUpdate,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    return await schedule_lists_service.update_packing_item(db, current_user.id, list_id, item_id, data)
+
+
+@router.delete("/{list_id}/packing-items/{item_id}", status_code=204)
+async def delete_packing_item(
+    list_id: int,
+    item_id: int,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    await schedule_lists_service.delete_packing_item(db, current_user.id, list_id, item_id)
+    return Response(status_code=204)

--- a/backend/app/api/schedules.py
+++ b/backend/app/api/schedules.py
@@ -1,0 +1,60 @@
+import datetime as dt
+
+from fastapi import APIRouter, Depends, Query, Response
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import get_db
+from app.dependencies.auth import get_current_user
+from app.models.user import User
+from app.schemas.schedules import ScheduleCreate, ScheduleResponse, ScheduleUpdate
+from app.services import schedules_service
+
+router = APIRouter(prefix="/schedules", tags=["schedules"])
+
+
+@router.get("", response_model=list[ScheduleResponse])
+async def list_schedules(
+    start_date: dt.date | None = Query(None),
+    end_date: dt.date | None = Query(None),
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    return await schedules_service.list_schedules(db, current_user.id, start_date, end_date)
+
+
+@router.post("", response_model=ScheduleResponse, status_code=201)
+async def create_schedule(
+    data: ScheduleCreate,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    return await schedules_service.create_schedule(db, current_user.id, data)
+
+
+@router.get("/{schedule_id}", response_model=ScheduleResponse)
+async def get_schedule(
+    schedule_id: int,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    return await schedules_service.get_schedule(db, current_user.id, schedule_id)
+
+
+@router.put("/{schedule_id}", response_model=ScheduleResponse)
+async def update_schedule(
+    schedule_id: int,
+    data: ScheduleUpdate,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    return await schedules_service.update_schedule(db, current_user.id, schedule_id, data)
+
+
+@router.delete("/{schedule_id}", status_code=204)
+async def delete_schedule(
+    schedule_id: int,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    await schedules_service.delete_schedule(db, current_user.id, schedule_id)
+    return Response(status_code=204)

--- a/backend/app/api/tags.py
+++ b/backend/app/api/tags.py
@@ -1,0 +1,18 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import get_db
+from app.dependencies.auth import get_current_user
+from app.models.user import User
+from app.schemas.tags import TagResponse
+from app.services import tags_service
+
+router = APIRouter(prefix="/tags", tags=["tags"])
+
+
+@router.get("", response_model=list[TagResponse])
+async def list_tags(
+    _current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    return await tags_service.list_tags(db)

--- a/backend/app/api/templates.py
+++ b/backend/app/api/templates.py
@@ -1,0 +1,72 @@
+from fastapi import APIRouter, Depends, Response
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import get_db
+from app.dependencies.auth import get_current_user
+from app.models.user import User
+from app.schemas.schedules import ScheduleResponse
+from app.schemas.templates import (
+    TemplateApplyRequest,
+    TemplateCreate,
+    TemplateResponse,
+    TemplateUpdate,
+)
+from app.services import templates_service
+
+router = APIRouter(prefix="/templates", tags=["templates"])
+
+
+@router.get("", response_model=list[TemplateResponse])
+async def list_templates(
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    return await templates_service.list_templates(db, current_user.id)
+
+
+@router.post("", response_model=TemplateResponse, status_code=201)
+async def create_template(
+    data: TemplateCreate,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    return await templates_service.create_template(db, current_user.id, data)
+
+
+@router.get("/{template_id}", response_model=TemplateResponse)
+async def get_template(
+    template_id: int,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    return await templates_service.get_template(db, current_user.id, template_id)
+
+
+@router.put("/{template_id}", response_model=TemplateResponse)
+async def update_template(
+    template_id: int,
+    data: TemplateUpdate,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    return await templates_service.update_template(db, current_user.id, template_id, data)
+
+
+@router.delete("/{template_id}", status_code=204)
+async def delete_template(
+    template_id: int,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    await templates_service.delete_template(db, current_user.id, template_id)
+    return Response(status_code=204)
+
+
+@router.post("/{template_id}/apply", response_model=list[ScheduleResponse], status_code=201)
+async def apply_template(
+    template_id: int,
+    data: TemplateApplyRequest,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    return await templates_service.apply_template(db, current_user.id, template_id, data.date)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,6 +4,10 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from app.api.auth import router as auth_router
 from app.api.healthz import router as healthz_router
+from app.api.schedule_lists import router as schedule_lists_router
+from app.api.schedules import router as schedules_router
+from app.api.tags import router as tags_router
+from app.api.templates import router as templates_router
 from app.api.users import router as users_router
 from app.config import settings
 from app.exceptions import (
@@ -31,3 +35,7 @@ app.add_exception_handler(Exception, generic_error_handler)
 app.include_router(healthz_router)
 app.include_router(auth_router, prefix="/api/v1")
 app.include_router(users_router, prefix="/api/v1")
+app.include_router(tags_router, prefix="/api/v1")
+app.include_router(schedules_router, prefix="/api/v1")
+app.include_router(schedule_lists_router, prefix="/api/v1")
+app.include_router(templates_router, prefix="/api/v1")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,5 +1,24 @@
 from app.models.base import Base
 from app.models.refresh_token import RefreshToken
+from app.models.schedule import Schedule
+from app.models.schedule_list import PackingItem, ScheduleList
+from app.models.schedule_route import ScheduleRoute
+from app.models.tag import Tag
+from app.models.template import Template, TemplateCategory, TemplateSchedule
 from app.models.user import NotificationSettings, User, UserSettings
 
-__all__ = ["Base", "User", "UserSettings", "NotificationSettings", "RefreshToken"]
+__all__ = [
+    "Base",
+    "NotificationSettings",
+    "PackingItem",
+    "RefreshToken",
+    "Schedule",
+    "ScheduleList",
+    "ScheduleRoute",
+    "Tag",
+    "Template",
+    "TemplateCategory",
+    "TemplateSchedule",
+    "User",
+    "UserSettings",
+]

--- a/backend/app/models/base.py
+++ b/backend/app/models/base.py
@@ -1,4 +1,7 @@
+from sqlalchemy import BigInteger
 from sqlalchemy.orm import DeclarativeBase
+
+BigInt = BigInteger
 
 
 class Base(DeclarativeBase):

--- a/backend/app/models/refresh_token.py
+++ b/backend/app/models/refresh_token.py
@@ -3,16 +3,13 @@ from __future__ import annotations
 from datetime import datetime
 from typing import TYPE_CHECKING
 
-from sqlalchemy import BigInteger, DateTime, ForeignKey, Integer, String, func
+from sqlalchemy import DateTime, ForeignKey, String, func
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
-from app.models.base import Base
+from app.models.base import Base, BigInt
 
 if TYPE_CHECKING:
     from app.models.user import User  # noqa: F401
-
-# SQLite では BIGINT の autoincrement が動かないため INTEGER にフォールバック
-BigInt = BigInteger().with_variant(Integer, "sqlite")
 
 
 class RefreshToken(Base):

--- a/backend/app/models/schedule.py
+++ b/backend/app/models/schedule.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from datetime import datetime
+from decimal import Decimal
+from typing import TYPE_CHECKING
+
+from sqlalchemy import DateTime, ForeignKey, Numeric, String, Text, func
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.models.base import Base, BigInt
+from app.models.tag import Tag, schedule_tags
+
+if TYPE_CHECKING:
+    from app.models.schedule_list import ScheduleList
+    from app.models.schedule_route import ScheduleRoute
+    from app.models.user import User
+
+
+class Schedule(Base):
+    __tablename__ = "schedules"
+
+    id: Mapped[int] = mapped_column(BigInt, primary_key=True, autoincrement=True)
+    user_id: Mapped[int] = mapped_column(BigInt, ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
+    schedule_list_id: Mapped[int | None] = mapped_column(
+        BigInt, ForeignKey("schedule_lists.id", ondelete="SET NULL"), nullable=True
+    )
+    title: Mapped[str] = mapped_column(String(255), nullable=False)
+    start_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    end_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    destination_name: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    destination_address: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    destination_lat: Mapped[Decimal | None] = mapped_column(Numeric(9, 6), nullable=True)
+    destination_lon: Mapped[Decimal | None] = mapped_column(Numeric(9, 6), nullable=True)
+    travel_mode: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    memo: Mapped[str | None] = mapped_column(Text, nullable=True)
+    recurrence_rule: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
+    )
+
+    user: Mapped[User] = relationship(back_populates="schedules")
+    schedule_list: Mapped[ScheduleList | None] = relationship(back_populates="schedules")
+    tags: Mapped[list[Tag]] = relationship(secondary=schedule_tags, lazy="selectin", passive_deletes=True)
+    selected_route: Mapped[ScheduleRoute | None] = relationship(
+        back_populates="schedule", uselist=False, cascade="all, delete-orphan"
+    )

--- a/backend/app/models/schedule_list.py
+++ b/backend/app/models/schedule_list.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import datetime as dt
+from typing import TYPE_CHECKING
+
+from sqlalchemy import Boolean, Date, DateTime, ForeignKey, Integer, String, func
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.models.base import Base, BigInt
+
+if TYPE_CHECKING:
+    from app.models.schedule import Schedule
+    from app.models.user import User
+
+
+class ScheduleList(Base):
+    __tablename__ = "schedule_lists"
+
+    id: Mapped[int] = mapped_column(BigInt, primary_key=True, autoincrement=True)
+    user_id: Mapped[int] = mapped_column(BigInt, ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
+    name: Mapped[str] = mapped_column(String(100), nullable=False)
+    date: Mapped[dt.date] = mapped_column(Date, nullable=False)
+    created_at: Mapped[dt.datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at: Mapped[dt.datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
+    )
+
+    user: Mapped[User] = relationship(back_populates="schedule_lists")
+    schedules: Mapped[list[Schedule]] = relationship(back_populates="schedule_list")
+    packing_items: Mapped[list[PackingItem]] = relationship(
+        back_populates="schedule_list", cascade="all, delete-orphan"
+    )
+
+
+class PackingItem(Base):
+    __tablename__ = "packing_items"
+
+    id: Mapped[int] = mapped_column(BigInt, primary_key=True, autoincrement=True)
+    schedule_list_id: Mapped[int] = mapped_column(
+        BigInt, ForeignKey("schedule_lists.id", ondelete="CASCADE"), nullable=False
+    )
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    is_checked: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default="false")
+    sort_order: Mapped[int] = mapped_column(Integer, nullable=False, server_default="0")
+
+    schedule_list: Mapped[ScheduleList] = relationship(back_populates="packing_items")

--- a/backend/app/models/schedule_route.py
+++ b/backend/app/models/schedule_route.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from sqlalchemy import DateTime, ForeignKey, Integer, Text, func
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.models.base import Base, BigInt
+
+if TYPE_CHECKING:
+    from app.models.schedule import Schedule
+
+
+class ScheduleRoute(Base):
+    __tablename__ = "schedule_routes"
+
+    id: Mapped[int] = mapped_column(BigInt, primary_key=True, autoincrement=True)
+    schedule_id: Mapped[int] = mapped_column(
+        BigInt, ForeignKey("schedules.id", ondelete="CASCADE"), nullable=False, unique=True
+    )
+    route_data: Mapped[str] = mapped_column(Text, nullable=False)
+    departure_time: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    arrival_time: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    duration_minutes: Mapped[int] = mapped_column(Integer, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+
+    schedule: Mapped[Schedule] = relationship(back_populates="selected_route")

--- a/backend/app/models/tag.py
+++ b/backend/app/models/tag.py
@@ -1,0 +1,27 @@
+from sqlalchemy import Column, ForeignKey, String, Table
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base, BigInt
+
+# Junction table: Schedule <-> Tag
+schedule_tags = Table(
+    "schedule_tags",
+    Base.metadata,
+    Column("schedule_id", BigInt, ForeignKey("schedules.id", ondelete="CASCADE"), primary_key=True),
+    Column("tag_id", BigInt, ForeignKey("tags.id", ondelete="CASCADE"), primary_key=True),
+)
+
+# Junction table: TemplateSchedule <-> Tag
+template_schedule_tags = Table(
+    "template_schedule_tags",
+    Base.metadata,
+    Column("template_schedule_id", BigInt, ForeignKey("template_schedules.id", ondelete="CASCADE"), primary_key=True),
+    Column("tag_id", BigInt, ForeignKey("tags.id", ondelete="CASCADE"), primary_key=True),
+)
+
+
+class Tag(Base):
+    __tablename__ = "tags"
+
+    id: Mapped[int] = mapped_column(BigInt, primary_key=True, autoincrement=True)
+    name: Mapped[str] = mapped_column(String(50), unique=True, nullable=False)

--- a/backend/app/models/template.py
+++ b/backend/app/models/template.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import datetime as dt
+from decimal import Decimal
+from typing import TYPE_CHECKING
+
+from sqlalchemy import DateTime, ForeignKey, Integer, Numeric, String, Text, Time, func
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.models.base import Base, BigInt
+from app.models.tag import Tag, template_schedule_tags
+
+if TYPE_CHECKING:
+    from app.models.user import User
+
+
+class TemplateCategory(Base):
+    __tablename__ = "template_categories"
+
+    id: Mapped[int] = mapped_column(BigInt, primary_key=True, autoincrement=True)
+    name: Mapped[str] = mapped_column(String(50), unique=True, nullable=False)
+
+    templates: Mapped[list[Template]] = relationship(back_populates="category")
+
+
+class Template(Base):
+    __tablename__ = "templates"
+
+    id: Mapped[int] = mapped_column(BigInt, primary_key=True, autoincrement=True)
+    user_id: Mapped[int] = mapped_column(BigInt, ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
+    name: Mapped[str] = mapped_column(String(100), nullable=False)
+    template_category_id: Mapped[int | None] = mapped_column(
+        BigInt, ForeignKey("template_categories.id", ondelete="SET NULL"), nullable=True
+    )
+    created_at: Mapped[dt.datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at: Mapped[dt.datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
+    )
+
+    user: Mapped[User] = relationship(back_populates="templates")
+    category: Mapped[TemplateCategory | None] = relationship(back_populates="templates")
+    schedules: Mapped[list[TemplateSchedule]] = relationship(
+        back_populates="template", cascade="all, delete-orphan", lazy="selectin"
+    )
+
+
+class TemplateSchedule(Base):
+    __tablename__ = "template_schedules"
+
+    id: Mapped[int] = mapped_column(BigInt, primary_key=True, autoincrement=True)
+    template_id: Mapped[int] = mapped_column(BigInt, ForeignKey("templates.id", ondelete="CASCADE"), nullable=False)
+    title: Mapped[str] = mapped_column(String(255), nullable=False)
+    start_time: Mapped[dt.time] = mapped_column(Time, nullable=False)
+    end_time: Mapped[dt.time | None] = mapped_column(Time, nullable=True)
+    destination_name: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    destination_address: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    destination_lat: Mapped[Decimal | None] = mapped_column(Numeric(9, 6), nullable=True)
+    destination_lon: Mapped[Decimal | None] = mapped_column(Numeric(9, 6), nullable=True)
+    travel_mode: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    memo: Mapped[str | None] = mapped_column(Text, nullable=True)
+    sort_order: Mapped[int] = mapped_column(Integer, nullable=False, server_default="0")
+
+    template: Mapped[Template] = relationship(back_populates="schedules")
+    tags: Mapped[list[Tag]] = relationship(secondary=template_schedule_tags, lazy="selectin", passive_deletes=True)

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -1,19 +1,19 @@
 from __future__ import annotations
 
-from datetime import datetime
+import datetime as dt
 from decimal import Decimal
 from typing import TYPE_CHECKING
 
-from sqlalchemy import BigInteger, Boolean, DateTime, ForeignKey, Integer, Numeric, String, Time, func
+from sqlalchemy import Boolean, DateTime, ForeignKey, Integer, Numeric, String, Time, func
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
-from app.models.base import Base
+from app.models.base import Base, BigInt
 
 if TYPE_CHECKING:
     from app.models.refresh_token import RefreshToken  # noqa: F401
-
-# SQLite では BIGINT の autoincrement が動かないため INTEGER にフォールバック
-BigInt = BigInteger().with_variant(Integer, "sqlite")
+    from app.models.schedule import Schedule  # noqa: F401
+    from app.models.schedule_list import ScheduleList  # noqa: F401
+    from app.models.template import Template  # noqa: F401
 
 
 class User(Base):
@@ -23,14 +23,17 @@ class User(Base):
     email: Mapped[str] = mapped_column(String(255), unique=True, nullable=False)
     password_hash: Mapped[str] = mapped_column(String, nullable=False)
     name: Mapped[str] = mapped_column(String(100), nullable=False)
-    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
-    updated_at: Mapped[datetime] = mapped_column(
+    created_at: Mapped[dt.datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at: Mapped[dt.datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
     )
 
     settings: Mapped[UserSettings] = relationship(back_populates="user")
     notification_settings: Mapped[NotificationSettings] = relationship(back_populates="user")
     refresh_tokens: Mapped[list[RefreshToken]] = relationship(back_populates="user")
+    schedules: Mapped[list[Schedule]] = relationship(back_populates="user")
+    schedule_lists: Mapped[list[ScheduleList]] = relationship(back_populates="user")
+    templates: Mapped[list[Template]] = relationship(back_populates="user")
 
 
 class UserSettings(Base):
@@ -46,8 +49,8 @@ class UserSettings(Base):
     preparation_minutes: Mapped[int] = mapped_column(Integer, nullable=False)
     reminder_minutes_before: Mapped[int] = mapped_column(Integer, nullable=False)
     timezone: Mapped[str] = mapped_column(String(50), nullable=False, server_default="Asia/Tokyo")
-    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
-    updated_at: Mapped[datetime] = mapped_column(
+    created_at: Mapped[dt.datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at: Mapped[dt.datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
     )
 
@@ -62,10 +65,10 @@ class NotificationSettings(Base):
         BigInt, ForeignKey("users.id", ondelete="CASCADE"), nullable=False, unique=True
     )
     weather_enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default="true")
-    weather_notify_time: Mapped[str] = mapped_column(Time, nullable=False, server_default="07:00:00")
+    weather_notify_time: Mapped[dt.time] = mapped_column(Time, nullable=False, server_default="07:00:00")
     reminder_enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default="true")
-    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
-    updated_at: Mapped[datetime] = mapped_column(
+    created_at: Mapped[dt.datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at: Mapped[dt.datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
     )
 

--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -1,11 +1,11 @@
 from datetime import datetime
 
-from pydantic import BaseModel, EmailStr
+from pydantic import BaseModel, EmailStr, Field
 
 
 class RegisterRequest(BaseModel):
     email: EmailStr
-    password: str
+    password: str = Field(min_length=8)
     name: str
     home_address: str
     home_lat: float

--- a/backend/app/schemas/schedule_lists.py
+++ b/backend/app/schemas/schedule_lists.py
@@ -1,0 +1,55 @@
+import datetime as dt
+
+from pydantic import BaseModel
+
+
+class PackingItemResponse(BaseModel):
+    id: int
+    name: str
+    is_checked: bool
+    sort_order: int
+
+    model_config = {"from_attributes": True}
+
+
+class PackingItemCreate(BaseModel):
+    name: str
+    sort_order: int = 0
+
+
+class PackingItemUpdate(BaseModel):
+    name: str | None = None
+    is_checked: bool | None = None
+    sort_order: int | None = None
+
+
+class ScheduleSummary(BaseModel):
+    id: int
+    title: str
+    start_at: dt.datetime
+    end_at: dt.datetime | None
+
+    model_config = {"from_attributes": True}
+
+
+class ScheduleListResponse(BaseModel):
+    id: int
+    name: str
+    date: dt.date
+    schedules: list[ScheduleSummary]
+    packing_items: list[PackingItemResponse]
+    created_at: dt.datetime
+    updated_at: dt.datetime
+
+    model_config = {"from_attributes": True}
+
+
+class ScheduleListCreate(BaseModel):
+    name: str
+    date: dt.date
+    packing_items: list[PackingItemCreate] = []
+
+
+class ScheduleListUpdate(BaseModel):
+    name: str | None = None
+    date: dt.date | None = None

--- a/backend/app/schemas/schedules.py
+++ b/backend/app/schemas/schedules.py
@@ -1,0 +1,63 @@
+from datetime import datetime
+from decimal import Decimal
+
+from pydantic import BaseModel
+
+from app.schemas.tags import TagResponse
+
+
+class SelectedRouteResponse(BaseModel):
+    id: int
+    departure_time: datetime
+    arrival_time: datetime
+    duration_minutes: int
+
+    model_config = {"from_attributes": True}
+
+
+class ScheduleResponse(BaseModel):
+    id: int
+    title: str
+    start_at: datetime
+    end_at: datetime | None
+    destination_name: str | None
+    destination_address: str | None
+    destination_lat: Decimal | None
+    destination_lon: Decimal | None
+    travel_mode: str | None
+    memo: str | None
+    schedule_list_id: int | None
+    tags: list[TagResponse]
+    selected_route: SelectedRouteResponse | None
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class ScheduleCreate(BaseModel):
+    title: str
+    start_at: datetime
+    end_at: datetime | None = None
+    destination_name: str | None = None
+    destination_address: str | None = None
+    destination_lat: Decimal | None = None
+    destination_lon: Decimal | None = None
+    travel_mode: str | None = None
+    memo: str | None = None
+    tag_ids: list[int] = []
+    schedule_list_id: int | None = None
+
+
+class ScheduleUpdate(BaseModel):
+    title: str | None = None
+    start_at: datetime | None = None
+    end_at: datetime | None = None
+    destination_name: str | None = None
+    destination_address: str | None = None
+    destination_lat: Decimal | None = None
+    destination_lon: Decimal | None = None
+    travel_mode: str | None = None
+    memo: str | None = None
+    tag_ids: list[int] | None = None
+    schedule_list_id: int | None = None

--- a/backend/app/schemas/tags.py
+++ b/backend/app/schemas/tags.py
@@ -1,0 +1,8 @@
+from pydantic import BaseModel
+
+
+class TagResponse(BaseModel):
+    id: int
+    name: str
+
+    model_config = {"from_attributes": True}

--- a/backend/app/schemas/templates.py
+++ b/backend/app/schemas/templates.py
@@ -1,0 +1,71 @@
+import datetime as dt
+from decimal import Decimal
+
+from pydantic import BaseModel
+
+from app.schemas.tags import TagResponse
+
+
+class TemplateCategoryResponse(BaseModel):
+    id: int
+    name: str
+
+    model_config = {"from_attributes": True}
+
+
+class TemplateScheduleResponse(BaseModel):
+    id: int
+    title: str
+    start_time: dt.time
+    end_time: dt.time | None
+    destination_name: str | None
+    destination_address: str | None
+    destination_lat: Decimal | None
+    destination_lon: Decimal | None
+    travel_mode: str | None
+    memo: str | None
+    sort_order: int
+    tags: list[TagResponse]
+
+    model_config = {"from_attributes": True}
+
+
+class TemplateResponse(BaseModel):
+    id: int
+    name: str
+    category: TemplateCategoryResponse | None
+    schedules: list[TemplateScheduleResponse]
+    created_at: dt.datetime
+    updated_at: dt.datetime
+
+    model_config = {"from_attributes": True}
+
+
+class TemplateScheduleCreate(BaseModel):
+    title: str
+    start_time: dt.time
+    end_time: dt.time | None = None
+    destination_name: str | None = None
+    destination_address: str | None = None
+    destination_lat: Decimal | None = None
+    destination_lon: Decimal | None = None
+    travel_mode: str | None = None
+    memo: str | None = None
+    tag_ids: list[int] = []
+    sort_order: int = 0
+
+
+class TemplateCreate(BaseModel):
+    name: str
+    category_id: int | None = None
+    schedules: list[TemplateScheduleCreate] = []
+
+
+class TemplateUpdate(BaseModel):
+    name: str | None = None
+    category_id: int | None = None
+    schedules: list[TemplateScheduleCreate] | None = None
+
+
+class TemplateApplyRequest(BaseModel):
+    date: dt.date

--- a/backend/app/services/auth_service.py
+++ b/backend/app/services/auth_service.py
@@ -88,10 +88,7 @@ async def refresh(db: AsyncSession, token: str) -> str:
     if refresh_token is None:
         raise AppError("UNAUTHORIZED", "Invalid refresh token", 401)
 
-    expires_at = (
-        refresh_token.expires_at if refresh_token.expires_at.tzinfo else refresh_token.expires_at.replace(tzinfo=UTC)
-    )
-    if expires_at < datetime.now(UTC):
+    if refresh_token.expires_at < datetime.now(UTC):
         raise AppError("UNAUTHORIZED", "Refresh token has expired", 401)
 
     access_token = create_access_token(refresh_token.user_id)

--- a/backend/app/services/schedule_lists_service.py
+++ b/backend/app/services/schedule_lists_service.py
@@ -1,0 +1,120 @@
+import datetime as dt
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.exceptions import AppError
+from app.models.schedule_list import PackingItem, ScheduleList
+from app.schemas.schedule_lists import (
+    PackingItemCreate,
+    PackingItemUpdate,
+    ScheduleListCreate,
+    ScheduleListUpdate,
+)
+
+
+async def _get_owned_list(db: AsyncSession, user_id: int, list_id: int) -> ScheduleList:
+    result = await db.execute(
+        select(ScheduleList)
+        .options(selectinload(ScheduleList.schedules), selectinload(ScheduleList.packing_items))
+        .where(ScheduleList.id == list_id, ScheduleList.user_id == user_id)
+    )
+    sl = result.scalar_one_or_none()
+    if sl is None:
+        raise AppError("NOT_FOUND", "Schedule list not found", 404)
+    return sl
+
+
+async def list_schedule_lists(
+    db: AsyncSession,
+    user_id: int,
+    start_date: dt.date | None = None,
+    end_date: dt.date | None = None,
+) -> list[ScheduleList]:
+    stmt = (
+        select(ScheduleList)
+        .options(selectinload(ScheduleList.schedules), selectinload(ScheduleList.packing_items))
+        .where(ScheduleList.user_id == user_id)
+        .order_by(ScheduleList.date)
+    )
+    if start_date is not None:
+        stmt = stmt.where(ScheduleList.date >= start_date)
+    if end_date is not None:
+        stmt = stmt.where(ScheduleList.date <= end_date)
+    result = await db.execute(stmt)
+    return list(result.scalars().all())
+
+
+async def create_schedule_list(db: AsyncSession, user_id: int, data: ScheduleListCreate) -> ScheduleList:
+    sl = ScheduleList(user_id=user_id, name=data.name, date=data.date)
+    db.add(sl)
+    await db.flush()
+
+    for item_data in data.packing_items:
+        item = PackingItem(schedule_list_id=sl.id, name=item_data.name, sort_order=item_data.sort_order)
+        db.add(item)
+
+    await db.commit()
+    return await _get_owned_list(db, user_id, sl.id)
+
+
+async def get_schedule_list(db: AsyncSession, user_id: int, list_id: int) -> ScheduleList:
+    return await _get_owned_list(db, user_id, list_id)
+
+
+async def update_schedule_list(db: AsyncSession, user_id: int, list_id: int, data: ScheduleListUpdate) -> ScheduleList:
+    sl = await _get_owned_list(db, user_id, list_id)
+    update_data = data.model_dump(exclude_unset=True)
+    for key, value in update_data.items():
+        setattr(sl, key, value)
+    await db.commit()
+    return await _get_owned_list(db, user_id, list_id)
+
+
+async def delete_schedule_list(db: AsyncSession, user_id: int, list_id: int) -> None:
+    sl = await _get_owned_list(db, user_id, list_id)
+    await db.delete(sl)
+    await db.commit()
+
+
+# --- Packing Items ---
+
+
+async def _get_owned_packing_item(db: AsyncSession, user_id: int, list_id: int, item_id: int) -> PackingItem:
+    # Verify ownership via schedule_list
+    await _get_owned_list(db, user_id, list_id)
+    result = await db.execute(
+        select(PackingItem).where(PackingItem.id == item_id, PackingItem.schedule_list_id == list_id)
+    )
+    item = result.scalar_one_or_none()
+    if item is None:
+        raise AppError("NOT_FOUND", "Packing item not found", 404)
+    return item
+
+
+async def create_packing_item(db: AsyncSession, user_id: int, list_id: int, data: PackingItemCreate) -> PackingItem:
+    await _get_owned_list(db, user_id, list_id)
+    item = PackingItem(schedule_list_id=list_id, name=data.name, sort_order=data.sort_order)
+    db.add(item)
+    await db.commit()
+    await db.refresh(item)
+    return item
+
+
+async def update_packing_item(
+    db: AsyncSession, user_id: int, list_id: int, item_id: int, data: PackingItemUpdate
+) -> PackingItem:
+    item = await _get_owned_packing_item(db, user_id, list_id, item_id)
+    update_data = data.model_dump(exclude_unset=True)
+    for key, value in update_data.items():
+        setattr(item, key, value)
+    await db.commit()
+    await db.refresh(item)
+    return item
+
+
+async def delete_packing_item(db: AsyncSession, user_id: int, list_id: int, item_id: int) -> None:
+    item = await _get_owned_packing_item(db, user_id, list_id, item_id)
+    await db.delete(item)
+    await db.commit()

--- a/backend/app/services/schedules_service.py
+++ b/backend/app/services/schedules_service.py
@@ -1,0 +1,115 @@
+import datetime as dt
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.exceptions import AppError
+from app.models.schedule import Schedule
+from app.models.tag import Tag, schedule_tags
+from app.schemas.schedules import ScheduleCreate, ScheduleUpdate
+
+
+async def _get_owned_schedule(db: AsyncSession, user_id: int, schedule_id: int) -> Schedule:
+    result = await db.execute(
+        select(Schedule)
+        .options(selectinload(Schedule.tags), selectinload(Schedule.selected_route))
+        .where(Schedule.id == schedule_id, Schedule.user_id == user_id)
+    )
+    schedule = result.scalar_one_or_none()
+    if schedule is None:
+        raise AppError("NOT_FOUND", "Schedule not found", 404)
+    return schedule
+
+
+async def _validate_tag_ids(db: AsyncSession, tag_ids: list[int]) -> None:
+    """tag_ids の存在チェック."""
+    if not tag_ids:
+        return
+    result = await db.execute(select(Tag.id).where(Tag.id.in_(tag_ids)))
+    found_ids = set(result.scalars().all())
+    missing = set(tag_ids) - found_ids
+    if missing:
+        raise AppError(
+            "VALIDATION_ERROR",
+            f"Tags not found: {sorted(missing)}",
+            400,
+        )
+
+
+async def list_schedules(
+    db: AsyncSession,
+    user_id: int,
+    start_date: dt.date | None = None,
+    end_date: dt.date | None = None,
+) -> list[Schedule]:
+    stmt = (
+        select(Schedule)
+        .options(selectinload(Schedule.tags), selectinload(Schedule.selected_route))
+        .where(Schedule.user_id == user_id)
+        .order_by(Schedule.start_at)
+    )
+    if start_date is not None:
+        stmt = stmt.where(Schedule.start_at >= dt.datetime.combine(start_date, dt.time.min))
+    if end_date is not None:
+        stmt = stmt.where(Schedule.start_at < dt.datetime.combine(end_date + dt.timedelta(days=1), dt.time.min))
+    result = await db.execute(stmt)
+    return list(result.scalars().all())
+
+
+async def create_schedule(db: AsyncSession, user_id: int, data: ScheduleCreate) -> Schedule:
+    await _validate_tag_ids(db, data.tag_ids)
+
+    schedule = Schedule(
+        user_id=user_id,
+        title=data.title,
+        start_at=data.start_at,
+        end_at=data.end_at,
+        destination_name=data.destination_name,
+        destination_address=data.destination_address,
+        destination_lat=data.destination_lat,
+        destination_lon=data.destination_lon,
+        travel_mode=data.travel_mode,
+        memo=data.memo,
+        schedule_list_id=data.schedule_list_id,
+    )
+    db.add(schedule)
+    await db.flush()
+
+    if data.tag_ids:
+        for tag_id in data.tag_ids:
+            await db.execute(schedule_tags.insert().values(schedule_id=schedule.id, tag_id=tag_id))
+
+    await db.commit()
+    return await _get_owned_schedule(db, user_id, schedule.id)
+
+
+async def get_schedule(db: AsyncSession, user_id: int, schedule_id: int) -> Schedule:
+    return await _get_owned_schedule(db, user_id, schedule_id)
+
+
+async def update_schedule(db: AsyncSession, user_id: int, schedule_id: int, data: ScheduleUpdate) -> Schedule:
+    schedule = await _get_owned_schedule(db, user_id, schedule_id)
+    update_data = data.model_dump(exclude_unset=True)
+
+    tag_ids = update_data.pop("tag_ids", None)
+
+    for key, value in update_data.items():
+        setattr(schedule, key, value)
+
+    if tag_ids is not None:
+        await _validate_tag_ids(db, tag_ids)
+        # Clear existing tags via raw SQL, then re-add
+        await db.execute(schedule_tags.delete().where(schedule_tags.c.schedule_id == schedule_id))
+        for tag_id in tag_ids:
+            await db.execute(schedule_tags.insert().values(schedule_id=schedule_id, tag_id=tag_id))
+
+    await db.commit()
+    db.expire(schedule)
+    return await _get_owned_schedule(db, user_id, schedule_id)
+
+
+async def delete_schedule(db: AsyncSession, user_id: int, schedule_id: int) -> None:
+    schedule = await _get_owned_schedule(db, user_id, schedule_id)
+    await db.delete(schedule)
+    await db.commit()

--- a/backend/app/services/tags_service.py
+++ b/backend/app/services/tags_service.py
@@ -1,0 +1,9 @@
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.tag import Tag
+
+
+async def list_tags(db: AsyncSession) -> list[Tag]:
+    result = await db.execute(select(Tag).order_by(Tag.id))
+    return list(result.scalars().all())

--- a/backend/app/services/templates_service.py
+++ b/backend/app/services/templates_service.py
@@ -1,0 +1,158 @@
+import datetime as dt
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.exceptions import AppError
+from app.models.schedule import Schedule
+from app.models.tag import schedule_tags, template_schedule_tags
+from app.models.template import Template, TemplateSchedule
+from app.schemas.templates import TemplateCreate, TemplateScheduleCreate, TemplateUpdate
+from app.services.schedules_service import _validate_tag_ids
+
+
+async def _get_owned_template(db: AsyncSession, user_id: int, template_id: int) -> Template:
+    result = await db.execute(
+        select(Template)
+        .options(
+            selectinload(Template.category),
+            selectinload(Template.schedules).selectinload(TemplateSchedule.tags),
+        )
+        .where(Template.id == template_id, Template.user_id == user_id)
+    )
+    template = result.scalar_one_or_none()
+    if template is None:
+        raise AppError("NOT_FOUND", "Template not found", 404)
+    return template
+
+
+async def _create_template_schedules(
+    db: AsyncSession, template_id: int, schedules_data: list[TemplateScheduleCreate]
+) -> None:
+    for s_data in schedules_data:
+        await _validate_tag_ids(db, s_data.tag_ids)
+        ts = TemplateSchedule(
+            template_id=template_id,
+            title=s_data.title,
+            start_time=s_data.start_time,
+            end_time=s_data.end_time,
+            destination_name=s_data.destination_name,
+            destination_address=s_data.destination_address,
+            destination_lat=s_data.destination_lat,
+            destination_lon=s_data.destination_lon,
+            travel_mode=s_data.travel_mode,
+            memo=s_data.memo,
+            sort_order=s_data.sort_order,
+        )
+        db.add(ts)
+        await db.flush()
+
+        if s_data.tag_ids:
+            for tag_id in s_data.tag_ids:
+                await db.execute(template_schedule_tags.insert().values(template_schedule_id=ts.id, tag_id=tag_id))
+
+
+async def list_templates(db: AsyncSession, user_id: int) -> list[Template]:
+    result = await db.execute(
+        select(Template)
+        .options(
+            selectinload(Template.category),
+            selectinload(Template.schedules).selectinload(TemplateSchedule.tags),
+        )
+        .where(Template.user_id == user_id)
+        .order_by(Template.id)
+    )
+    return list(result.scalars().all())
+
+
+async def create_template(db: AsyncSession, user_id: int, data: TemplateCreate) -> Template:
+    template = Template(
+        user_id=user_id,
+        name=data.name,
+        template_category_id=data.category_id,
+    )
+    db.add(template)
+    await db.flush()
+
+    await _create_template_schedules(db, template.id, data.schedules)
+
+    await db.commit()
+    return await _get_owned_template(db, user_id, template.id)
+
+
+async def get_template(db: AsyncSession, user_id: int, template_id: int) -> Template:
+    return await _get_owned_template(db, user_id, template_id)
+
+
+async def update_template(db: AsyncSession, user_id: int, template_id: int, data: TemplateUpdate) -> Template:
+    template = await _get_owned_template(db, user_id, template_id)
+    update_data = data.model_dump(exclude_unset=True)
+
+    schedules_data = update_data.pop("schedules", None)
+
+    if "category_id" in update_data:
+        template.template_category_id = update_data.pop("category_id")
+
+    for key, value in update_data.items():
+        setattr(template, key, value)
+
+    if schedules_data is not None:
+        # Delete existing template schedules (cascade deletes junction table rows)
+        template.schedules.clear()
+        await db.flush()
+
+        # Create new ones
+        parsed = [TemplateScheduleCreate(**s) for s in schedules_data]
+        await _create_template_schedules(db, template_id, parsed)
+
+    await db.commit()
+    db.expire(template)
+    return await _get_owned_template(db, user_id, template_id)
+
+
+async def delete_template(db: AsyncSession, user_id: int, template_id: int) -> Template:
+    template = await _get_owned_template(db, user_id, template_id)
+    await db.delete(template)
+    await db.commit()
+
+
+async def apply_template(db: AsyncSession, user_id: int, template_id: int, date: dt.date) -> list[Schedule]:
+    template = await _get_owned_template(db, user_id, template_id)
+
+    created_ids: list[int] = []
+    for ts in sorted(template.schedules, key=lambda s: s.sort_order):
+        start_at = dt.datetime.combine(date, ts.start_time)
+        end_at = dt.datetime.combine(date, ts.end_time) if ts.end_time else None
+
+        schedule = Schedule(
+            user_id=user_id,
+            title=ts.title,
+            start_at=start_at,
+            end_at=end_at,
+            destination_name=ts.destination_name,
+            destination_address=ts.destination_address,
+            destination_lat=ts.destination_lat,
+            destination_lon=ts.destination_lon,
+            travel_mode=ts.travel_mode,
+            memo=ts.memo,
+        )
+        db.add(schedule)
+        await db.flush()
+
+        # Copy tags via junction table insert
+        for tag in ts.tags:
+            await db.execute(schedule_tags.insert().values(schedule_id=schedule.id, tag_id=tag.id))
+
+        created_ids.append(schedule.id)
+
+    await db.commit()
+
+    # Batch re-fetch with relationships (resolves N+1)
+    result = await db.execute(
+        select(Schedule)
+        .options(selectinload(Schedule.tags), selectinload(Schedule.selected_route))
+        .where(Schedule.id.in_(created_ids))
+        .order_by(Schedule.start_at)
+    )
+    return list(result.scalars().all())

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -11,6 +11,3 @@ mypy
 pytest
 pytest-asyncio
 httpx
-
-# テスト用 SQLite ドライバ
-aiosqlite

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,5 +1,6 @@
-"""テスト共通フィクスチャ — SQLite + TestClient."""
+"""テスト共通フィクスチャ — PostgreSQL + TestClient."""
 
+import os
 from collections.abc import AsyncGenerator
 
 import pytest_asyncio
@@ -9,9 +10,14 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_asyn
 from app.database import get_db
 from app.main import app
 from app.models.base import Base
+from app.models.tag import Tag
+from app.models.template import TemplateCategory
 
-# テスト用 SQLite（インメモリ）
-TEST_DATABASE_URL = "sqlite+aiosqlite:///:memory:"
+# テスト用 PostgreSQL（環境変数 or docker-compose のデフォルト）
+TEST_DATABASE_URL = os.environ.get(
+    "DATABASE_URL",
+    "postgresql+asyncpg://tenichi:tenichi@localhost:5432/tenichi",
+)
 
 engine = create_async_engine(TEST_DATABASE_URL, echo=False)
 TestSessionLocal = async_sessionmaker(engine, expire_on_commit=False)
@@ -22,6 +28,15 @@ async def setup_db():
     """テストごとにテーブルを作成・削除."""
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
+
+    # Seed tags and template categories
+    async with TestSessionLocal() as session:
+        for name in ["仕事", "会食", "デート", "運動"]:
+            session.add(Tag(name=name))
+        for name in ["仕事の日", "在宅勤務", "休日"]:
+            session.add(TemplateCategory(name=name))
+        await session.commit()
+
     yield
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.drop_all)
@@ -43,3 +58,33 @@ async def client() -> AsyncGenerator[AsyncClient]:
     """httpx AsyncClient（FastAPI TestClient 相当）."""
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
         yield c
+
+
+# --- 共通テストヘルパー ---
+
+REGISTER_DATA = {
+    "email": "test@example.com",
+    "password": "Password123",
+    "name": "Test User",
+    "home_address": "東京都渋谷区",
+    "home_lat": 35.6584,
+    "home_lon": 139.7015,
+    "preparation_minutes": 30,
+    "reminder_minutes_before": 15,
+}
+
+
+async def register_user(client: AsyncClient, email: str | None = None) -> dict:
+    """テストユーザーを登録し、レスポンス全体を返す."""
+    data = {**REGISTER_DATA}
+    if email:
+        data["email"] = email
+    response = await client.post("/api/v1/auth/register", json=data)
+    assert response.status_code == 201
+    return response.json()
+
+
+async def auth_headers(client: AsyncClient, email: str | None = None) -> dict:
+    """テストユーザーを登録し、認証ヘッダーを返す."""
+    result = await register_user(client, email)
+    return {"Authorization": f"Bearer {result['access_token']}"}

--- a/backend/tests/test_api_auth.py
+++ b/backend/tests/test_api_auth.py
@@ -2,16 +2,7 @@
 
 import pytest
 
-REGISTER_DATA = {
-    "email": "test@example.com",
-    "password": "password123",
-    "name": "Test User",
-    "home_address": "東京都渋谷区",
-    "home_lat": 35.6584,
-    "home_lon": 139.7015,
-    "preparation_minutes": 30,
-    "reminder_minutes_before": 15,
-}
+from tests.conftest import REGISTER_DATA, register_user
 
 
 @pytest.mark.asyncio
@@ -40,17 +31,19 @@ class TestRegister:
         response = await client.post("/api/v1/auth/register", json=invalid_data)
         assert response.status_code == 422
 
+    async def test_register_short_password(self, client):
+        short_pw_data = {**REGISTER_DATA, "email": "short@example.com", "password": "short"}
+        response = await client.post("/api/v1/auth/register", json=short_pw_data)
+        assert response.status_code == 422
+
 
 @pytest.mark.asyncio
 class TestLogin:
-    async def _register(self, client):
-        await client.post("/api/v1/auth/register", json=REGISTER_DATA)
-
     async def test_login_success(self, client):
-        await self._register(client)
+        await register_user(client)
         response = await client.post(
             "/api/v1/auth/login",
-            json={"email": "test@example.com", "password": "password123"},
+            json={"email": "test@example.com", "password": "Password123"},
         )
         assert response.status_code == 200
         data = response.json()
@@ -59,7 +52,7 @@ class TestLogin:
         assert data["expires_in"] > 0
 
     async def test_login_wrong_password(self, client):
-        await self._register(client)
+        await register_user(client)
         response = await client.post(
             "/api/v1/auth/login",
             json={"email": "test@example.com", "password": "wrongpassword"},
@@ -70,19 +63,15 @@ class TestLogin:
     async def test_login_nonexistent_email(self, client):
         response = await client.post(
             "/api/v1/auth/login",
-            json={"email": "nobody@example.com", "password": "password123"},
+            json={"email": "nobody@example.com", "password": "Password123"},
         )
         assert response.status_code == 401
 
 
 @pytest.mark.asyncio
 class TestRefresh:
-    async def _register_and_get_tokens(self, client) -> dict:
-        response = await client.post("/api/v1/auth/register", json=REGISTER_DATA)
-        return response.json()
-
     async def test_refresh_success(self, client):
-        tokens = await self._register_and_get_tokens(client)
+        tokens = await register_user(client)
         response = await client.post(
             "/api/v1/auth/refresh",
             json={"refresh_token": tokens["refresh_token"]},
@@ -102,12 +91,8 @@ class TestRefresh:
 
 @pytest.mark.asyncio
 class TestLogout:
-    async def _register_and_get_tokens(self, client) -> dict:
-        response = await client.post("/api/v1/auth/register", json=REGISTER_DATA)
-        return response.json()
-
     async def test_logout_success(self, client):
-        tokens = await self._register_and_get_tokens(client)
+        tokens = await register_user(client)
         response = await client.post(
             "/api/v1/auth/logout",
             headers={"Authorization": f"Bearer {tokens['access_token']}"},

--- a/backend/tests/test_api_schedule_lists.py
+++ b/backend/tests/test_api_schedule_lists.py
@@ -1,0 +1,129 @@
+"""schedule-lists API エンドポイントのテスト."""
+
+import pytest
+
+from tests.conftest import auth_headers
+
+SL_DATA = {
+    "name": "出社の日",
+    "date": "2026-03-10",
+    "packing_items": [
+        {"name": "折りたたみ傘", "sort_order": 1},
+        {"name": "名刺", "sort_order": 2},
+    ],
+}
+
+
+async def _create_list(client, headers, data=None):
+    return await client.post("/api/v1/schedule-lists", headers=headers, json=data or SL_DATA)
+
+
+@pytest.mark.asyncio
+class TestCreateScheduleList:
+    async def test_create_success(self, client):
+        headers = await auth_headers(client)
+        response = await _create_list(client, headers)
+        assert response.status_code == 201
+        data = response.json()
+        assert data["name"] == "出社の日"
+        assert data["date"] == "2026-03-10"
+        assert len(data["packing_items"]) == 2
+        assert data["packing_items"][0]["name"] == "折りたたみ傘"
+
+    async def test_create_without_token(self, client):
+        response = await client.post("/api/v1/schedule-lists", json=SL_DATA)
+        assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+class TestListScheduleLists:
+    async def test_list_with_date_filter(self, client):
+        headers = await auth_headers(client)
+        await _create_list(client, headers)
+        response = await client.get("/api/v1/schedule-lists?start_date=2026-03-10&end_date=2026-03-10", headers=headers)
+        assert response.status_code == 200
+        assert len(response.json()) == 1
+
+
+@pytest.mark.asyncio
+class TestGetScheduleList:
+    async def test_get_success(self, client):
+        headers = await auth_headers(client)
+        create_resp = await _create_list(client, headers)
+        list_id = create_resp.json()["id"]
+        response = await client.get(f"/api/v1/schedule-lists/{list_id}", headers=headers)
+        assert response.status_code == 200
+        assert response.json()["name"] == "出社の日"
+
+    async def test_get_not_found(self, client):
+        headers = await auth_headers(client)
+        response = await client.get("/api/v1/schedule-lists/999", headers=headers)
+        assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+class TestUpdateScheduleList:
+    async def test_update_name(self, client):
+        headers = await auth_headers(client)
+        create_resp = await _create_list(client, headers)
+        list_id = create_resp.json()["id"]
+        response = await client.put(f"/api/v1/schedule-lists/{list_id}", headers=headers, json={"name": "在宅の日"})
+        assert response.status_code == 200
+        assert response.json()["name"] == "在宅の日"
+
+
+@pytest.mark.asyncio
+class TestDeleteScheduleList:
+    async def test_delete_success(self, client):
+        headers = await auth_headers(client)
+        create_resp = await _create_list(client, headers)
+        list_id = create_resp.json()["id"]
+        response = await client.delete(f"/api/v1/schedule-lists/{list_id}", headers=headers)
+        assert response.status_code == 204
+
+
+@pytest.mark.asyncio
+class TestPackingItems:
+    async def test_create_packing_item(self, client):
+        headers = await auth_headers(client)
+        create_resp = await _create_list(client, headers)
+        list_id = create_resp.json()["id"]
+        response = await client.post(
+            f"/api/v1/schedule-lists/{list_id}/packing-items",
+            headers=headers,
+            json={"name": "手土産", "sort_order": 3},
+        )
+        assert response.status_code == 201
+        assert response.json()["name"] == "手土産"
+
+    async def test_update_packing_item(self, client):
+        headers = await auth_headers(client)
+        create_resp = await _create_list(client, headers)
+        list_id = create_resp.json()["id"]
+        item_id = create_resp.json()["packing_items"][0]["id"]
+        response = await client.put(
+            f"/api/v1/schedule-lists/{list_id}/packing-items/{item_id}",
+            headers=headers,
+            json={"is_checked": True},
+        )
+        assert response.status_code == 200
+        assert response.json()["is_checked"] is True
+
+    async def test_delete_packing_item(self, client):
+        headers = await auth_headers(client)
+        create_resp = await _create_list(client, headers)
+        list_id = create_resp.json()["id"]
+        item_id = create_resp.json()["packing_items"][0]["id"]
+        response = await client.delete(f"/api/v1/schedule-lists/{list_id}/packing-items/{item_id}", headers=headers)
+        assert response.status_code == 204
+
+    async def test_packing_item_not_found(self, client):
+        headers = await auth_headers(client)
+        create_resp = await _create_list(client, headers)
+        list_id = create_resp.json()["id"]
+        response = await client.put(
+            f"/api/v1/schedule-lists/{list_id}/packing-items/999",
+            headers=headers,
+            json={"name": "x"},
+        )
+        assert response.status_code == 404

--- a/backend/tests/test_api_schedules.py
+++ b/backend/tests/test_api_schedules.py
@@ -1,0 +1,138 @@
+"""schedules API エンドポイントのテスト."""
+
+import pytest
+
+from tests.conftest import auth_headers
+
+SCHEDULE_DATA = {
+    "title": "会食",
+    "start_at": "2026-03-10T19:00:00",
+    "end_at": "2026-03-10T21:00:00",
+    "destination_name": "銀座 鮨さいとう",
+    "destination_address": "東京都中央区銀座",
+    "travel_mode": "transit",
+    "memo": "手土産を持参",
+    "tag_ids": [2],
+}
+
+
+async def _create_schedule(client, headers, data=None):
+    return await client.post("/api/v1/schedules", headers=headers, json=data or SCHEDULE_DATA)
+
+
+@pytest.mark.asyncio
+class TestCreateSchedule:
+    async def test_create_success(self, client):
+        headers = await auth_headers(client)
+        response = await _create_schedule(client, headers)
+        assert response.status_code == 201
+        data = response.json()
+        assert data["title"] == "会食"
+        assert data["travel_mode"] == "transit"
+        assert len(data["tags"]) == 1
+        assert data["tags"][0]["name"] == "会食"
+        assert data["selected_route"] is None
+
+    async def test_create_with_invalid_tag(self, client):
+        headers = await auth_headers(client)
+        data = {**SCHEDULE_DATA, "tag_ids": [999]}
+        response = await _create_schedule(client, headers, data)
+        assert response.status_code == 400
+        assert response.json()["error"]["code"] == "VALIDATION_ERROR"
+
+    async def test_create_without_token(self, client):
+        response = await client.post("/api/v1/schedules", json=SCHEDULE_DATA)
+        assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+class TestListSchedules:
+    async def test_list_empty(self, client):
+        headers = await auth_headers(client)
+        response = await client.get("/api/v1/schedules", headers=headers)
+        assert response.status_code == 200
+        assert response.json() == []
+
+    async def test_list_with_data(self, client):
+        headers = await auth_headers(client)
+        await _create_schedule(client, headers)
+        response = await client.get("/api/v1/schedules", headers=headers)
+        assert response.status_code == 200
+        assert len(response.json()) == 1
+
+    async def test_list_with_date_filter(self, client):
+        headers = await auth_headers(client)
+        await _create_schedule(client, headers)
+        # Within range
+        response = await client.get("/api/v1/schedules?start_date=2026-03-10&end_date=2026-03-10", headers=headers)
+        assert len(response.json()) == 1
+        # Outside range
+        response = await client.get("/api/v1/schedules?start_date=2026-03-11&end_date=2026-03-11", headers=headers)
+        assert len(response.json()) == 0
+
+
+@pytest.mark.asyncio
+class TestGetSchedule:
+    async def test_get_success(self, client):
+        headers = await auth_headers(client)
+        create_resp = await _create_schedule(client, headers)
+        schedule_id = create_resp.json()["id"]
+        response = await client.get(f"/api/v1/schedules/{schedule_id}", headers=headers)
+        assert response.status_code == 200
+        assert response.json()["title"] == "会食"
+
+    async def test_get_not_found(self, client):
+        headers = await auth_headers(client)
+        response = await client.get("/api/v1/schedules/999", headers=headers)
+        assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+class TestUpdateSchedule:
+    async def test_update_partial(self, client):
+        headers = await auth_headers(client)
+        create_resp = await _create_schedule(client, headers)
+        schedule_id = create_resp.json()["id"]
+        response = await client.put(
+            f"/api/v1/schedules/{schedule_id}",
+            headers=headers,
+            json={"title": "更新済み", "tag_ids": [1, 3]},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["title"] == "更新済み"
+        assert len(data["tags"]) == 2
+
+    async def test_update_with_invalid_tag(self, client):
+        headers = await auth_headers(client)
+        create_resp = await _create_schedule(client, headers)
+        schedule_id = create_resp.json()["id"]
+        response = await client.put(
+            f"/api/v1/schedules/{schedule_id}",
+            headers=headers,
+            json={"tag_ids": [999]},
+        )
+        assert response.status_code == 400
+
+    async def test_update_not_found(self, client):
+        headers = await auth_headers(client)
+        response = await client.put("/api/v1/schedules/999", headers=headers, json={"title": "x"})
+        assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+class TestDeleteSchedule:
+    async def test_delete_success(self, client):
+        headers = await auth_headers(client)
+        create_resp = await _create_schedule(client, headers)
+        schedule_id = create_resp.json()["id"]
+        response = await client.delete(f"/api/v1/schedules/{schedule_id}", headers=headers)
+        assert response.status_code == 204
+        # Verify deleted
+        response = await client.get(f"/api/v1/schedules/{schedule_id}", headers=headers)
+        assert response.status_code == 404
+
+    async def test_delete_not_found(self, client):
+        headers = await auth_headers(client)
+        response = await client.delete("/api/v1/schedules/999", headers=headers)
+        assert response.status_code == 404

--- a/backend/tests/test_api_tags.py
+++ b/backend/tests/test_api_tags.py
@@ -1,0 +1,24 @@
+"""tags API エンドポイントのテスト."""
+
+import pytest
+
+from tests.conftest import auth_headers
+
+
+@pytest.mark.asyncio
+class TestListTags:
+    async def test_list_tags_success(self, client):
+        headers = await auth_headers(client)
+        response = await client.get("/api/v1/tags", headers=headers)
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 4
+        names = [t["name"] for t in data]
+        assert "仕事" in names
+        assert "会食" in names
+        assert "デート" in names
+        assert "運動" in names
+
+    async def test_list_tags_without_token(self, client):
+        response = await client.get("/api/v1/tags")
+        assert response.status_code == 403

--- a/backend/tests/test_api_templates.py
+++ b/backend/tests/test_api_templates.py
@@ -1,0 +1,149 @@
+"""templates API エンドポイントのテスト."""
+
+import pytest
+
+from tests.conftest import auth_headers
+
+TEMPLATE_DATA = {
+    "name": "仕事の日ルーティン",
+    "category_id": 1,
+    "schedules": [
+        {
+            "title": "朝の準備",
+            "start_time": "07:30:00",
+            "end_time": "08:30:00",
+            "memo": "スーツ着用",
+            "tag_ids": [1],
+            "sort_order": 1,
+        },
+        {
+            "title": "オフィス出勤",
+            "start_time": "09:00:00",
+            "end_time": "18:00:00",
+            "destination_name": "本社オフィス",
+            "travel_mode": "transit",
+            "sort_order": 2,
+        },
+    ],
+}
+
+
+async def _create_template(client, headers, data=None):
+    return await client.post("/api/v1/templates", headers=headers, json=data or TEMPLATE_DATA)
+
+
+@pytest.mark.asyncio
+class TestCreateTemplate:
+    async def test_create_success(self, client):
+        headers = await auth_headers(client)
+        response = await _create_template(client, headers)
+        assert response.status_code == 201
+        data = response.json()
+        assert data["name"] == "仕事の日ルーティン"
+        assert data["category"]["name"] == "仕事の日"
+        assert len(data["schedules"]) == 2
+        assert data["schedules"][0]["title"] == "朝の準備"
+        assert len(data["schedules"][0]["tags"]) == 1
+
+    async def test_create_without_token(self, client):
+        response = await client.post("/api/v1/templates", json=TEMPLATE_DATA)
+        assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+class TestListTemplates:
+    async def test_list_empty(self, client):
+        headers = await auth_headers(client)
+        response = await client.get("/api/v1/templates", headers=headers)
+        assert response.status_code == 200
+        assert response.json() == []
+
+    async def test_list_with_data(self, client):
+        headers = await auth_headers(client)
+        await _create_template(client, headers)
+        response = await client.get("/api/v1/templates", headers=headers)
+        assert len(response.json()) == 1
+
+
+@pytest.mark.asyncio
+class TestGetTemplate:
+    async def test_get_success(self, client):
+        headers = await auth_headers(client)
+        create_resp = await _create_template(client, headers)
+        template_id = create_resp.json()["id"]
+        response = await client.get(f"/api/v1/templates/{template_id}", headers=headers)
+        assert response.status_code == 200
+        assert response.json()["name"] == "仕事の日ルーティン"
+
+    async def test_get_not_found(self, client):
+        headers = await auth_headers(client)
+        response = await client.get("/api/v1/templates/999", headers=headers)
+        assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+class TestUpdateTemplate:
+    async def test_update_name(self, client):
+        headers = await auth_headers(client)
+        create_resp = await _create_template(client, headers)
+        template_id = create_resp.json()["id"]
+        response = await client.put(
+            f"/api/v1/templates/{template_id}", headers=headers, json={"name": "更新ルーティン"}
+        )
+        assert response.status_code == 200
+        assert response.json()["name"] == "更新ルーティン"
+        # Schedules should remain
+        assert len(response.json()["schedules"]) == 2
+
+    async def test_update_replace_schedules(self, client):
+        headers = await auth_headers(client)
+        create_resp = await _create_template(client, headers)
+        template_id = create_resp.json()["id"]
+        response = await client.put(
+            f"/api/v1/templates/{template_id}",
+            headers=headers,
+            json={"schedules": [{"title": "新しい予定", "start_time": "10:00:00", "sort_order": 1}]},
+        )
+        assert response.status_code == 200
+        assert len(response.json()["schedules"]) == 1
+        assert response.json()["schedules"][0]["title"] == "新しい予定"
+
+
+@pytest.mark.asyncio
+class TestDeleteTemplate:
+    async def test_delete_success(self, client):
+        headers = await auth_headers(client)
+        create_resp = await _create_template(client, headers)
+        template_id = create_resp.json()["id"]
+        response = await client.delete(f"/api/v1/templates/{template_id}", headers=headers)
+        assert response.status_code == 204
+
+    async def test_delete_not_found(self, client):
+        headers = await auth_headers(client)
+        response = await client.delete("/api/v1/templates/999", headers=headers)
+        assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+class TestApplyTemplate:
+    async def test_apply_success(self, client):
+        headers = await auth_headers(client)
+        create_resp = await _create_template(client, headers)
+        template_id = create_resp.json()["id"]
+        response = await client.post(
+            f"/api/v1/templates/{template_id}/apply",
+            headers=headers,
+            json={"date": "2026-03-10"},
+        )
+        assert response.status_code == 201
+        data = response.json()
+        assert len(data) == 2
+        assert data[0]["title"] == "朝の準備"
+        assert data[0]["start_at"] is not None
+        assert len(data[0]["tags"]) == 1
+        assert data[1]["title"] == "オフィス出勤"
+
+    async def test_apply_not_found(self, client):
+        headers = await auth_headers(client)
+        response = await client.post("/api/v1/templates/999/apply", headers=headers, json={"date": "2026-03-10"})
+        assert response.status_code == 404

--- a/backend/tests/test_api_users.py
+++ b/backend/tests/test_api_users.py
@@ -2,35 +2,17 @@
 
 import pytest
 
-REGISTER_DATA = {
-    "email": "user@example.com",
-    "password": "password123",
-    "name": "Test User",
-    "home_address": "東京都渋谷区",
-    "home_lat": 35.6584,
-    "home_lon": 139.7015,
-    "preparation_minutes": 30,
-    "reminder_minutes_before": 15,
-}
-
-
-async def _register_and_get_token(client) -> str:
-    response = await client.post("/api/v1/auth/register", json=REGISTER_DATA)
-    return response.json()["access_token"]
-
-
-def _auth_headers(token: str) -> dict:
-    return {"Authorization": f"Bearer {token}"}
+from tests.conftest import auth_headers
 
 
 @pytest.mark.asyncio
 class TestGetProfile:
     async def test_get_profile_success(self, client):
-        token = await _register_and_get_token(client)
-        response = await client.get("/api/v1/users/me", headers=_auth_headers(token))
+        headers = await auth_headers(client)
+        response = await client.get("/api/v1/users/me", headers=headers)
         assert response.status_code == 200
         data = response.json()
-        assert data["email"] == "user@example.com"
+        assert data["email"] == "test@example.com"
         assert data["name"] == "Test User"
         assert "id" in data
         assert "created_at" in data
@@ -43,20 +25,20 @@ class TestGetProfile:
 @pytest.mark.asyncio
 class TestUpdateProfile:
     async def test_update_name(self, client):
-        token = await _register_and_get_token(client)
+        headers = await auth_headers(client)
         response = await client.put(
             "/api/v1/users/me",
-            headers=_auth_headers(token),
+            headers=headers,
             json={"name": "Updated Name"},
         )
         assert response.status_code == 200
         assert response.json()["name"] == "Updated Name"
 
     async def test_update_empty_body(self, client):
-        token = await _register_and_get_token(client)
+        headers = await auth_headers(client)
         response = await client.put(
             "/api/v1/users/me",
-            headers=_auth_headers(token),
+            headers=headers,
             json={},
         )
         assert response.status_code == 200
@@ -70,8 +52,8 @@ class TestUpdateProfile:
 @pytest.mark.asyncio
 class TestGetSettings:
     async def test_get_settings_success(self, client):
-        token = await _register_and_get_token(client)
-        response = await client.get("/api/v1/users/me/settings", headers=_auth_headers(token))
+        headers = await auth_headers(client)
+        response = await client.get("/api/v1/users/me/settings", headers=headers)
         assert response.status_code == 200
         data = response.json()
         assert data["home_address"] == "東京都渋谷区"
@@ -87,10 +69,10 @@ class TestGetSettings:
 @pytest.mark.asyncio
 class TestUpdateSettings:
     async def test_update_partial(self, client):
-        token = await _register_and_get_token(client)
+        headers = await auth_headers(client)
         response = await client.put(
             "/api/v1/users/me/settings",
-            headers=_auth_headers(token),
+            headers=headers,
             json={"preparation_minutes": 45, "home_address": "東京都新宿区"},
         )
         assert response.status_code == 200
@@ -100,10 +82,10 @@ class TestUpdateSettings:
         assert data["reminder_minutes_before"] == 15  # unchanged
 
     async def test_update_empty_body(self, client):
-        token = await _register_and_get_token(client)
+        headers = await auth_headers(client)
         response = await client.put(
             "/api/v1/users/me/settings",
-            headers=_auth_headers(token),
+            headers=headers,
             json={},
         )
         assert response.status_code == 200

--- a/backend/tests/test_schemas.py
+++ b/backend/tests/test_schemas.py
@@ -10,7 +10,7 @@ class TestRegisterRequest:
     def test_valid_input(self):
         data = RegisterRequest(
             email="test@example.com",
-            password="password123",
+            password="Password123",
             name="Test User",
             home_address="東京都渋谷区",
             home_lat=35.6584,
@@ -25,7 +25,7 @@ class TestRegisterRequest:
         with pytest.raises(ValidationError) as exc_info:
             RegisterRequest(
                 email="not-an-email",
-                password="password123",
+                password="Password123",
                 name="Test User",
                 home_address="東京都渋谷区",
                 home_lat=35.6584,
@@ -39,8 +39,21 @@ class TestRegisterRequest:
         with pytest.raises(ValidationError):
             RegisterRequest(
                 email="test@example.com",
-                password="password123",
+                password="Password123",
                 # name が欠落
+            )
+
+    def test_short_password(self):
+        with pytest.raises(ValidationError):
+            RegisterRequest(
+                email="test@example.com",
+                password="short",
+                name="Test User",
+                home_address="東京都渋谷区",
+                home_lat=35.6584,
+                home_lon=139.7015,
+                preparation_minutes=30,
+                reminder_minutes_before=15,
             )
 
 
@@ -48,7 +61,7 @@ class TestLoginRequest:
     def test_valid_input(self):
         data = LoginRequest(
             email="test@example.com",
-            password="password123",
+            password="Password123",
         )
         assert data.email == "test@example.com"
 
@@ -56,5 +69,5 @@ class TestLoginRequest:
         with pytest.raises(ValidationError):
             LoginRequest(
                 email="invalid",
-                password="password123",
+                password="Password123",
             )


### PR DESCRIPTION
## Summary
- Phase 5 コアAPI の全実装（モデル・スキーマ・サービス・ルーター・テスト・マイグレーション）
- Tags: `GET /tags`（事前定義タグ一覧）
- Schedules: CRUD 5エンドポイント（日付フィルタ、タグ紐付け対応）
- ScheduleLists: CRUD + PackingItems CRUD（8エンドポイント）
- Templates: CRUD + apply（6エンドポイント、テンプレート適用で Schedule 一括作成）
- コードレビュー指摘事項の修正（テスト基盤の PostgreSQL 移行、tag_id バリデーション追加、passive_deletes 対応、N+1 解消等）

## Test plan
- [x] `ruff check .` パス
- [x] `ruff format --check .` パス
- [x] `pytest tests/ -v` → 82 passed
- [x] CI (GitHub Actions) グリーン確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)