### PR TITLE
feat: Phase 8 — 経路API (Routes) + ScheduleRoute CRUD

### DIFF
--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -1,0 +1,33 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import get_db
+from app.dependencies.auth import get_current_user
+from app.models.user import User
+from app.schemas.routes import (
+    DepartureTimeRequest,
+    DepartureTimeResponse,
+    RouteSearchRequest,
+    RouteSearchResponse,
+)
+from app.services import routes_service
+
+router = APIRouter(prefix="/routes", tags=["routes"])
+
+
+@router.post("/search", response_model=RouteSearchResponse)
+async def search_routes(
+    data: RouteSearchRequest,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    return await routes_service.search_routes(db, current_user.id, data)
+
+
+@router.post("/departure-time", response_model=DepartureTimeResponse)
+async def calculate_departure_time(
+    data: DepartureTimeRequest,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    return await routes_service.calculate_departure_time(db, current_user.id, data)

--- a/backend/app/api/schedule_routes.py
+++ b/backend/app/api/schedule_routes.py
@@ -1,0 +1,39 @@
+from fastapi import APIRouter, Depends, Response
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import get_db
+from app.dependencies.auth import get_current_user
+from app.models.user import User
+from app.schemas.routes import ScheduleRouteCreate, ScheduleRouteResponse
+from app.services import routes_service
+
+router = APIRouter(prefix="/schedules", tags=["schedule-routes"])
+
+
+@router.post("/{schedule_id}/route", response_model=ScheduleRouteResponse, status_code=201)
+async def save_route(
+    schedule_id: int,
+    data: ScheduleRouteCreate,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    return await routes_service.save_route(db, current_user.id, schedule_id, data)
+
+
+@router.get("/{schedule_id}/route", response_model=ScheduleRouteResponse)
+async def get_route(
+    schedule_id: int,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    return await routes_service.get_route(db, current_user.id, schedule_id)
+
+
+@router.delete("/{schedule_id}/route", status_code=204)
+async def delete_route(
+    schedule_id: int,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    await routes_service.delete_route(db, current_user.id, schedule_id)
+    return Response(status_code=204)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -5,7 +5,9 @@ from fastapi.middleware.cors import CORSMiddleware
 from app.api.auth import router as auth_router
 from app.api.healthz import router as healthz_router
 from app.api.notifications import router as notifications_router
+from app.api.routes import router as routes_router
 from app.api.schedule_lists import router as schedule_lists_router
+from app.api.schedule_routes import router as schedule_routes_router
 from app.api.schedules import router as schedules_router
 from app.api.tags import router as tags_router
 from app.api.templates import router as templates_router
@@ -42,4 +44,6 @@ app.include_router(schedules_router, prefix="/api/v1")
 app.include_router(schedule_lists_router, prefix="/api/v1")
 app.include_router(templates_router, prefix="/api/v1")
 app.include_router(weather_router, prefix="/api/v1")
+app.include_router(routes_router, prefix="/api/v1")
+app.include_router(schedule_routes_router, prefix="/api/v1")
 app.include_router(notifications_router, prefix="/api/v1")

--- a/backend/app/schemas/routes.py
+++ b/backend/app/schemas/routes.py
@@ -1,0 +1,95 @@
+import json
+from datetime import datetime
+
+from pydantic import BaseModel, field_validator, model_validator
+
+VALID_TRAVEL_MODES = {"transit", "walking", "cycling", "driving"}
+
+
+class RouteSearchRequest(BaseModel):
+    origin_lat: float | None = None
+    origin_lon: float | None = None
+    destination_lat: float
+    destination_lon: float
+    travel_mode: str
+    arrival_time: datetime | None = None
+
+    @model_validator(mode="after")
+    def validate_travel_mode(self):
+        if self.travel_mode not in VALID_TRAVEL_MODES:
+            msg = f"travel_mode must be one of {sorted(VALID_TRAVEL_MODES)}"
+            raise ValueError(msg)
+        return self
+
+
+class DepartureTimeRequest(BaseModel):
+    destination_lat: float
+    destination_lon: float
+    arrival_time: datetime
+    travel_mode: str
+
+    @model_validator(mode="after")
+    def validate_travel_mode(self):
+        if self.travel_mode not in VALID_TRAVEL_MODES:
+            msg = f"travel_mode must be one of {sorted(VALID_TRAVEL_MODES)}"
+            raise ValueError(msg)
+        return self
+
+
+class ScheduleRouteCreate(BaseModel):
+    route_data: dict
+    departure_time: datetime
+    arrival_time: datetime
+    duration_minutes: int
+
+
+class LegResponse(BaseModel):
+    mode: str
+    from_name: str
+    to_name: str
+    departure_time: datetime
+    arrival_time: datetime
+    duration_minutes: int
+    route_short_name: str | None = None
+    route_long_name: str | None = None
+    agency_name: str | None = None
+    headsign: str | None = None
+
+
+class ItineraryResponse(BaseModel):
+    departure_time: datetime
+    arrival_time: datetime
+    duration_minutes: int
+    number_of_transfers: int | None = None
+    legs: list[LegResponse]
+
+
+class RouteSearchResponse(BaseModel):
+    itineraries: list[ItineraryResponse]
+
+
+class DepartureTimeResponse(BaseModel):
+    leave_home_at: datetime
+    start_preparation_at: datetime
+    preparation_minutes: int
+    arrival_time: datetime
+    itineraries: list[ItineraryResponse]
+
+
+class ScheduleRouteResponse(BaseModel):
+    id: int
+    schedule_id: int
+    route_data: dict
+    departure_time: datetime
+    arrival_time: datetime
+    duration_minutes: int
+    created_at: datetime
+
+    model_config = {"from_attributes": True}
+
+    @field_validator("route_data", mode="before")
+    @classmethod
+    def parse_route_data(cls, v):
+        if isinstance(v, str):
+            return json.loads(v)
+        return v

--- a/backend/app/services/otp2_client.py
+++ b/backend/app/services/otp2_client.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+import logging
+
+import httpx
+
+from app.config import settings
+from app.exceptions import AppError
+
+logger = logging.getLogger(__name__)
+
+
+def _get_auth_headers() -> dict[str, str]:
+    """OTP2 向け認証ヘッダーを取得する（本番環境のみ）."""
+    if settings.ENVIRONMENT == "development":
+        return {}
+
+    import google.auth.transport.requests  # noqa: I001
+    import google.oauth2.id_token
+
+    request = google.auth.transport.requests.Request()
+    token = google.oauth2.id_token.fetch_id_token(request, settings.OTP2_GRAPHQL_URL)
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _build_modes(travel_mode: str) -> str:
+    """travel_mode を OTP2 GraphQL modes フラグメントに変換."""
+    if travel_mode == "transit":
+        return "{ transit: { transit: [{ mode: RAIL }, { mode: SUBWAY }, { mode: BUS }] }, direct: [WALK] }"
+    mode_map = {
+        "walking": "WALK",
+        "cycling": "BICYCLE",
+        "driving": "CAR",
+    }
+    return f"{{ direct: [{mode_map[travel_mode]}] }}"
+
+
+def _build_query(
+    origin_lat: float,
+    origin_lon: float,
+    dest_lat: float,
+    dest_lon: float,
+    travel_mode: str,
+    arrival_time: str | None = None,
+    departure_time: str | None = None,
+) -> str:
+    """OTP2 planConnection GraphQL クエリを構築する."""
+    modes = _build_modes(travel_mode)
+    num_results = 5 if travel_mode == "transit" else 1
+
+    if arrival_time:
+        datetime_arg = f'dateTime: {{ latestArrival: "{arrival_time}" }}'
+    elif departure_time:
+        datetime_arg = f'dateTime: {{ earliestDeparture: "{departure_time}" }}'
+    else:
+        datetime_arg = 'dateTime: { earliestDeparture: "now" }'
+
+    return f"""
+    {{
+      planConnection(
+        origin: {{
+          location: {{ coordinate: {{ latitude: {origin_lat}, longitude: {origin_lon} }} }}
+        }}
+        destination: {{
+          location: {{ coordinate: {{ latitude: {dest_lat}, longitude: {dest_lon} }} }}
+        }}
+        {datetime_arg}
+        modes: {modes}
+        first: {num_results}
+      ) {{
+        edges {{
+          node {{
+            start
+            end
+            duration
+            numberOfTransfers
+            legs {{
+              mode
+              route {{
+                shortName
+                longName
+                agency {{ name }}
+              }}
+              from {{ name }}
+              to {{ name }}
+              start {{ scheduledTime }}
+              end {{ scheduledTime }}
+              headsign
+            }}
+          }}
+        }}
+      }}
+    }}
+    """
+
+
+def _parse_leg(leg: dict) -> dict:
+    """OTP2 の leg → API レスポンス形式に変換."""
+    start_time = leg["start"]["scheduledTime"]
+    end_time = leg["end"]["scheduledTime"]
+
+    result: dict = {
+        "mode": leg["mode"],
+        "from_name": leg["from"]["name"],
+        "to_name": leg["to"]["name"],
+        "departure_time": start_time,
+        "arrival_time": end_time,
+    }
+
+    # duration は start/end から計算（OTP2 の leg には duration がない）
+    from datetime import datetime
+
+    dep = datetime.fromisoformat(start_time)
+    arr = datetime.fromisoformat(end_time)
+    result["duration_minutes"] = max(1, int((arr - dep).total_seconds() / 60))
+
+    # transit 専用フィールド
+    route = leg.get("route")
+    if route:
+        if route.get("shortName"):
+            result["route_short_name"] = route["shortName"]
+        if route.get("longName"):
+            result["route_long_name"] = route["longName"]
+        agency = route.get("agency")
+        if agency and agency.get("name"):
+            result["agency_name"] = agency["name"]
+    if leg.get("headsign"):
+        result["headsign"] = leg["headsign"]
+
+    return result
+
+
+def _parse_itineraries(data: dict) -> list[dict]:
+    """OTP2 レスポンス全体 → itineraries リストに変換."""
+    edges = data.get("data", {}).get("planConnection", {}).get("edges", [])
+    itineraries = []
+    for edge in edges:
+        node = edge["node"]
+        duration_seconds = node.get("duration", 0)
+        itinerary: dict = {
+            "departure_time": node["start"],
+            "arrival_time": node["end"],
+            "duration_minutes": max(1, int(duration_seconds / 60)),
+            "legs": [_parse_leg(leg) for leg in node.get("legs", [])],
+        }
+        num_transfers = node.get("numberOfTransfers")
+        if num_transfers is not None:
+            itinerary["number_of_transfers"] = num_transfers
+        itineraries.append(itinerary)
+    return itineraries
+
+
+async def search_routes(
+    origin_lat: float,
+    origin_lon: float,
+    dest_lat: float,
+    dest_lon: float,
+    travel_mode: str,
+    arrival_time: str | None = None,
+    departure_time: str | None = None,
+) -> list[dict]:
+    """OTP2 に経路検索リクエストを送信し、itineraries を返す."""
+    query = _build_query(
+        origin_lat,
+        origin_lon,
+        dest_lat,
+        dest_lon,
+        travel_mode,
+        arrival_time=arrival_time,
+        departure_time=departure_time,
+    )
+
+    try:
+        headers = _get_auth_headers()
+        headers["Content-Type"] = "application/json"
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(
+                settings.OTP2_GRAPHQL_URL,
+                json={"query": query},
+                headers=headers,
+                timeout=30.0,
+            )
+            if resp.status_code != 200:
+                logger.warning("OTP2 returned status %d: %s", resp.status_code, resp.text[:200])
+                raise AppError("OTP_UNAVAILABLE", "Route planning service request failed", 503)
+
+            data = resp.json()
+
+            # GraphQL エラーチェック
+            if data.get("errors"):
+                logger.warning("OTP2 GraphQL error: %s", data["errors"][0].get("message"))
+                raise AppError("ROUTE_NOT_FOUND", "No routes found for the specified conditions", 404)
+    except AppError:
+        raise
+    except httpx.HTTPError:
+        logger.exception("OTP2 connection error")
+        raise AppError("OTP_UNAVAILABLE", "Route planning service is unavailable", 503) from None
+
+    itineraries = _parse_itineraries(data)
+    if not itineraries:
+        raise AppError("ROUTE_NOT_FOUND", "No routes found for the specified conditions", 404)
+
+    return itineraries

--- a/backend/app/services/routes_service.py
+++ b/backend/app/services/routes_service.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import json
+from datetime import timedelta
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.exceptions import AppError
+from app.models.schedule import Schedule
+from app.models.schedule_route import ScheduleRoute
+from app.models.user import UserSettings
+from app.schemas.routes import DepartureTimeRequest, RouteSearchRequest, ScheduleRouteCreate
+from app.services import otp2_client
+
+
+async def _get_user_settings(db: AsyncSession, user_id: int) -> UserSettings:
+    result = await db.execute(select(UserSettings).where(UserSettings.user_id == user_id))
+    settings = result.scalar_one_or_none()
+    if settings is None:
+        raise AppError("NOT_FOUND", "User settings not found", 404)
+    return settings
+
+
+async def _get_owned_schedule(db: AsyncSession, user_id: int, schedule_id: int) -> Schedule:
+    result = await db.execute(select(Schedule).where(Schedule.id == schedule_id, Schedule.user_id == user_id))
+    schedule = result.scalar_one_or_none()
+    if schedule is None:
+        raise AppError("NOT_FOUND", "Schedule not found", 404)
+    return schedule
+
+
+async def search_routes(db: AsyncSession, user_id: int, data: RouteSearchRequest) -> dict:
+    origin_lat = data.origin_lat
+    origin_lon = data.origin_lon
+
+    if origin_lat is None or origin_lon is None:
+        settings = await _get_user_settings(db, user_id)
+        if settings.home_lat is None or settings.home_lon is None:
+            raise AppError("HOME_LOCATION_NOT_SET", "Home location is not set in user settings", 400)
+        origin_lat = float(settings.home_lat)
+        origin_lon = float(settings.home_lon)
+
+    arrival_time_str = data.arrival_time.isoformat() if data.arrival_time else None
+
+    itineraries = await otp2_client.search_routes(
+        origin_lat=origin_lat,
+        origin_lon=origin_lon,
+        dest_lat=data.destination_lat,
+        dest_lon=data.destination_lon,
+        travel_mode=data.travel_mode,
+        arrival_time=arrival_time_str,
+    )
+
+    return {"itineraries": itineraries}
+
+
+async def calculate_departure_time(db: AsyncSession, user_id: int, data: DepartureTimeRequest) -> dict:
+    settings = await _get_user_settings(db, user_id)
+
+    if settings.home_lat is None or settings.home_lon is None:
+        raise AppError("HOME_LOCATION_NOT_SET", "Home location is not set in user settings", 400)
+
+    itineraries = await otp2_client.search_routes(
+        origin_lat=float(settings.home_lat),
+        origin_lon=float(settings.home_lon),
+        dest_lat=data.destination_lat,
+        dest_lon=data.destination_lon,
+        travel_mode=data.travel_mode,
+        arrival_time=data.arrival_time.isoformat(),
+    )
+
+    from datetime import datetime
+
+    first = itineraries[0]
+    leave_home_at = datetime.fromisoformat(first["departure_time"])
+    preparation_minutes = settings.preparation_minutes
+    start_preparation_at = leave_home_at - timedelta(minutes=preparation_minutes)
+
+    return {
+        "leave_home_at": leave_home_at.isoformat(),
+        "start_preparation_at": start_preparation_at.isoformat(),
+        "preparation_minutes": preparation_minutes,
+        "arrival_time": data.arrival_time.isoformat(),
+        "itineraries": itineraries,
+    }
+
+
+async def save_route(db: AsyncSession, user_id: int, schedule_id: int, data: ScheduleRouteCreate) -> ScheduleRoute:
+    await _get_owned_schedule(db, user_id, schedule_id)
+
+    # 既存ルートがあれば削除
+    result = await db.execute(select(ScheduleRoute).where(ScheduleRoute.schedule_id == schedule_id))
+    existing = result.scalar_one_or_none()
+    if existing:
+        await db.delete(existing)
+        await db.flush()
+
+    route = ScheduleRoute(
+        schedule_id=schedule_id,
+        route_data=json.dumps(data.route_data, ensure_ascii=False),
+        departure_time=data.departure_time,
+        arrival_time=data.arrival_time,
+        duration_minutes=data.duration_minutes,
+    )
+    db.add(route)
+    await db.commit()
+    await db.refresh(route)
+    return route
+
+
+async def get_route(db: AsyncSession, user_id: int, schedule_id: int) -> ScheduleRoute:
+    await _get_owned_schedule(db, user_id, schedule_id)
+
+    result = await db.execute(select(ScheduleRoute).where(ScheduleRoute.schedule_id == schedule_id))
+    route = result.scalar_one_or_none()
+    if route is None:
+        raise AppError("NOT_FOUND", "Route not found for this schedule", 404)
+
+    return route
+
+
+async def delete_route(db: AsyncSession, user_id: int, schedule_id: int) -> None:
+    await _get_owned_schedule(db, user_id, schedule_id)
+
+    result = await db.execute(select(ScheduleRoute).where(ScheduleRoute.schedule_id == schedule_id))
+    route = result.scalar_one_or_none()
+    if route is None:
+        raise AppError("NOT_FOUND", "Route not found for this schedule", 404)
+
+    await db.delete(route)
+    await db.commit()

--- a/backend/tests/test_api_routes.py
+++ b/backend/tests/test_api_routes.py
@@ -1,0 +1,147 @@
+"""routes API エンドポイントのテスト."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from tests.conftest import auth_headers
+
+MOCK_ITINERARIES = [
+    {
+        "departure_time": "2026-03-10T18:12:00+09:00",
+        "arrival_time": "2026-03-10T18:58:00+09:00",
+        "duration_minutes": 46,
+        "number_of_transfers": 1,
+        "legs": [
+            {
+                "mode": "WALK",
+                "from_name": "出発地",
+                "to_name": "高円寺駅",
+                "departure_time": "2026-03-10T18:12:00+09:00",
+                "arrival_time": "2026-03-10T18:20:00+09:00",
+                "duration_minutes": 8,
+            },
+            {
+                "mode": "RAIL",
+                "route_short_name": "中央線",
+                "agency_name": "JR東日本",
+                "headsign": "東京方面",
+                "from_name": "高円寺駅",
+                "to_name": "新宿駅",
+                "departure_time": "2026-03-10T18:23:00+09:00",
+                "arrival_time": "2026-03-10T18:29:00+09:00",
+                "duration_minutes": 6,
+            },
+        ],
+    }
+]
+
+SEARCH_DATA = {
+    "origin_lat": 35.6895,
+    "origin_lon": 139.6917,
+    "destination_lat": 35.6580,
+    "destination_lon": 139.7016,
+    "travel_mode": "transit",
+}
+
+
+@pytest.mark.asyncio
+class TestSearchRoutes:
+    @patch("app.services.otp2_client.search_routes", new_callable=AsyncMock)
+    async def test_search_success(self, mock_otp2, client):
+        mock_otp2.return_value = MOCK_ITINERARIES
+        headers = await auth_headers(client)
+        response = await client.post("/api/v1/routes/search", headers=headers, json=SEARCH_DATA)
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["itineraries"]) == 1
+        assert data["itineraries"][0]["duration_minutes"] == 46
+        assert len(data["itineraries"][0]["legs"]) == 2
+
+    @patch("app.services.otp2_client.search_routes", new_callable=AsyncMock)
+    async def test_search_home_fallback(self, mock_otp2, client):
+        """origin 省略時に UserSettings.home_lat/lon をフォールバック."""
+        mock_otp2.return_value = MOCK_ITINERARIES
+        headers = await auth_headers(client)
+        data = {
+            "destination_lat": 35.6580,
+            "destination_lon": 139.7016,
+            "travel_mode": "transit",
+        }
+        response = await client.post("/api/v1/routes/search", headers=headers, json=data)
+        assert response.status_code == 200
+        # OTP2 に home_lat/lon が渡されたことを確認
+        call_args = mock_otp2.call_args
+        assert call_args.kwargs["origin_lat"] == pytest.approx(35.6584, abs=0.001)
+        assert call_args.kwargs["origin_lon"] == pytest.approx(139.7015, abs=0.001)
+
+    async def test_search_without_token(self, client):
+        response = await client.post("/api/v1/routes/search", json=SEARCH_DATA)
+        assert response.status_code == 403
+
+    async def test_search_invalid_travel_mode(self, client):
+        headers = await auth_headers(client)
+        data = {**SEARCH_DATA, "travel_mode": "teleport"}
+        response = await client.post("/api/v1/routes/search", headers=headers, json=data)
+        assert response.status_code == 422
+
+    @patch("app.services.otp2_client.search_routes", new_callable=AsyncMock)
+    async def test_search_otp_unavailable(self, mock_otp2, client):
+        from app.exceptions import AppError
+
+        mock_otp2.side_effect = AppError("OTP_UNAVAILABLE", "Route planning service is unavailable", 503)
+        headers = await auth_headers(client)
+        response = await client.post("/api/v1/routes/search", headers=headers, json=SEARCH_DATA)
+        assert response.status_code == 503
+        assert response.json()["error"]["code"] == "OTP_UNAVAILABLE"
+
+    @patch("app.services.otp2_client.search_routes", new_callable=AsyncMock)
+    async def test_search_route_not_found(self, mock_otp2, client):
+        from app.exceptions import AppError
+
+        mock_otp2.side_effect = AppError("ROUTE_NOT_FOUND", "No routes found", 404)
+        headers = await auth_headers(client)
+        response = await client.post("/api/v1/routes/search", headers=headers, json=SEARCH_DATA)
+        assert response.status_code == 404
+        assert response.json()["error"]["code"] == "ROUTE_NOT_FOUND"
+
+
+DEPARTURE_TIME_DATA = {
+    "destination_lat": 35.6580,
+    "destination_lon": 139.7016,
+    "arrival_time": "2026-03-10T19:00:00+09:00",
+    "travel_mode": "transit",
+}
+
+
+@pytest.mark.asyncio
+class TestDepartureTime:
+    @patch("app.services.otp2_client.search_routes", new_callable=AsyncMock)
+    async def test_departure_time_success(self, mock_otp2, client):
+        mock_otp2.return_value = MOCK_ITINERARIES
+        headers = await auth_headers(client)
+        response = await client.post("/api/v1/routes/departure-time", headers=headers, json=DEPARTURE_TIME_DATA)
+        assert response.status_code == 200
+        data = response.json()
+        assert "leave_home_at" in data
+        assert "start_preparation_at" in data
+        assert data["preparation_minutes"] == 30
+        assert len(data["itineraries"]) == 1
+
+    @patch("app.services.otp2_client.search_routes", new_callable=AsyncMock)
+    async def test_departure_time_preparation_calculation(self, mock_otp2, client):
+        """preparation_minutes が正しく計算されるか確認."""
+        mock_otp2.return_value = MOCK_ITINERARIES
+        headers = await auth_headers(client)
+        response = await client.post("/api/v1/routes/departure-time", headers=headers, json=DEPARTURE_TIME_DATA)
+        assert response.status_code == 200
+        data = response.json()
+        from datetime import datetime, timedelta
+
+        leave = datetime.fromisoformat(data["leave_home_at"])
+        start_prep = datetime.fromisoformat(data["start_preparation_at"])
+        assert leave - start_prep == timedelta(minutes=30)
+
+    async def test_departure_time_without_token(self, client):
+        response = await client.post("/api/v1/routes/departure-time", json=DEPARTURE_TIME_DATA)
+        assert response.status_code == 403

--- a/backend/tests/test_api_schedule_routes.py
+++ b/backend/tests/test_api_schedule_routes.py
@@ -1,0 +1,104 @@
+"""schedule_routes API エンドポイントのテスト."""
+
+import pytest
+
+from tests.conftest import auth_headers
+
+SCHEDULE_DATA = {
+    "title": "会食",
+    "start_at": "2026-03-10T19:00:00",
+}
+
+ROUTE_DATA = {
+    "route_data": {
+        "legs": [
+            {
+                "mode": "WALK",
+                "from_name": "出発地",
+                "to_name": "渋谷駅",
+                "duration_minutes": 10,
+            }
+        ]
+    },
+    "departure_time": "2026-03-10T18:12:00+09:00",
+    "arrival_time": "2026-03-10T18:58:00+09:00",
+    "duration_minutes": 46,
+}
+
+
+async def _create_schedule(client, headers):
+    resp = await client.post("/api/v1/schedules", headers=headers, json=SCHEDULE_DATA)
+    assert resp.status_code == 201
+    return resp.json()["id"]
+
+
+@pytest.mark.asyncio
+class TestSaveRoute:
+    async def test_save_success(self, client):
+        headers = await auth_headers(client)
+        schedule_id = await _create_schedule(client, headers)
+        response = await client.post(f"/api/v1/schedules/{schedule_id}/route", headers=headers, json=ROUTE_DATA)
+        assert response.status_code == 201
+        data = response.json()
+        assert data["schedule_id"] == schedule_id
+        assert data["duration_minutes"] == 46
+        assert data["route_data"]["legs"][0]["mode"] == "WALK"
+
+    async def test_save_replaces_existing(self, client):
+        headers = await auth_headers(client)
+        schedule_id = await _create_schedule(client, headers)
+        await client.post(f"/api/v1/schedules/{schedule_id}/route", headers=headers, json=ROUTE_DATA)
+        new_data = {**ROUTE_DATA, "duration_minutes": 30}
+        response = await client.post(f"/api/v1/schedules/{schedule_id}/route", headers=headers, json=new_data)
+        assert response.status_code == 201
+        assert response.json()["duration_minutes"] == 30
+
+    async def test_save_schedule_not_found(self, client):
+        headers = await auth_headers(client)
+        response = await client.post("/api/v1/schedules/9999/route", headers=headers, json=ROUTE_DATA)
+        assert response.status_code == 404
+
+    async def test_save_other_user(self, client):
+        headers1 = await auth_headers(client, email="user1@example.com")
+        schedule_id = await _create_schedule(client, headers1)
+        headers2 = await auth_headers(client, email="user2@example.com")
+        response = await client.post(f"/api/v1/schedules/{schedule_id}/route", headers=headers2, json=ROUTE_DATA)
+        assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+class TestGetRoute:
+    async def test_get_success(self, client):
+        headers = await auth_headers(client)
+        schedule_id = await _create_schedule(client, headers)
+        await client.post(f"/api/v1/schedules/{schedule_id}/route", headers=headers, json=ROUTE_DATA)
+        response = await client.get(f"/api/v1/schedules/{schedule_id}/route", headers=headers)
+        assert response.status_code == 200
+        data = response.json()
+        assert data["schedule_id"] == schedule_id
+        assert data["route_data"]["legs"][0]["mode"] == "WALK"
+
+    async def test_get_not_saved(self, client):
+        headers = await auth_headers(client)
+        schedule_id = await _create_schedule(client, headers)
+        response = await client.get(f"/api/v1/schedules/{schedule_id}/route", headers=headers)
+        assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+class TestDeleteRoute:
+    async def test_delete_success(self, client):
+        headers = await auth_headers(client)
+        schedule_id = await _create_schedule(client, headers)
+        await client.post(f"/api/v1/schedules/{schedule_id}/route", headers=headers, json=ROUTE_DATA)
+        response = await client.delete(f"/api/v1/schedules/{schedule_id}/route", headers=headers)
+        assert response.status_code == 204
+        # Verify deleted
+        get_resp = await client.get(f"/api/v1/schedules/{schedule_id}/route", headers=headers)
+        assert get_resp.status_code == 404
+
+    async def test_delete_not_saved(self, client):
+        headers = await auth_headers(client)
+        schedule_id = await _create_schedule(client, headers)
+        response = await client.delete(f"/api/v1/schedules/{schedule_id}/route", headers=headers)
+        assert response.status_code == 404


### PR DESCRIPTION
## Summary

- OTP2 GraphQL クライアント (`otp2_client.py`) を実装（httpx + Cloud Run google-auth 対応）
- `POST /routes/search` — 経路検索（transit/walking/cycling/driving 対応）
- `POST /routes/departure-time` — 出発時刻逆算（UserSettings の home_lat/lon/preparation_minutes を自動取得）
- `POST/GET/DELETE /schedules/{id}/route` — 選択ルート保存 CRUD
- テスト 17件追加（全130件 passed）

## Test plan

- [x] `ruff check .` — All checks passed
- [x] `ruff format --check .` — All formatted
- [x] `pytest tests/ -v` — 130 passed
- [x] CI (GitHub Actions) で lint + test が通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)