### PR TITLE
【develop】hotfix: GCPデプロイ時の修正とドキュメント更新

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -13,7 +13,7 @@ config = context.config
 if config.config_file_name is not None:
     fileConfig(config.config_file_name)
 
-config.set_main_option("sqlalchemy.url", settings.DATABASE_URL)
+config.set_main_option("sqlalchemy.url", settings.DATABASE_URL.replace("%", "%%"))
 
 target_metadata = Base.metadata
 

--- a/backend/app/services/otp2_client.py
+++ b/backend/app/services/otp2_client.py
@@ -17,9 +17,14 @@ def _get_auth_headers() -> dict[str, str]:
 
     import google.auth.transport.requests  # noqa: I001
     import google.oauth2.id_token
+    from urllib.parse import urlparse
+
+    # audience はベースURL（パスなし）にする必要がある
+    parsed = urlparse(settings.OTP2_GRAPHQL_URL)
+    audience = f"{parsed.scheme}://{parsed.netloc}"
 
     request = google.auth.transport.requests.Request()
-    token = google.oauth2.id_token.fetch_id_token(request, settings.OTP2_GRAPHQL_URL)
+    token = google.oauth2.id_token.fetch_id_token(request, audience)
     return {"Authorization": f"Bearer {token}"}
 
 

--- a/backend/docs/tasks/tikcets/gcp-initial-deploy.md
+++ b/backend/docs/tasks/tikcets/gcp-initial-deploy.md
@@ -1,0 +1,58 @@
+# GCP 初回デプロイ
+
+## 背景
+ハッカソンのデモに向けて、FastAPI Backend と OTP2 Server を GCP Cloud Run にデプロイする必要があった。
+インフラ構築手順書（`infra/docs/インフラ構築手順書.md`）の §1〜§8 を実施。
+
+## 作業内容
+
+### 1. GCP基盤セットアップ（§1〜§5）
+- GCPプロジェクト `schedule-t-y-k-app` のセットアップ確認
+- 5つのAPI有効化（Cloud Run, Cloud Build, Artifact Registry, Secret Manager, Vertex AI）
+- サービスアカウント作成（fastapi-sa, otp2-sa）+ IAM権限付与
+- Artifact Registry `app` リポジトリ作成
+- Secret Manager に6つのシークレット作成:
+  - SUPABASE_URL, SUPABASE_KEY, JWT_SECRET, WEATHERAPI_KEY, OTP2_GRAPHQL_URL, DATABASE_URL
+
+### 2. FastAPI Backend デプロイ（§6）
+- Cloud Buildでイメージビルド＆Artifact Registryにプッシュ
+- Cloud Run にデプロイ（512Mi/1CPU, ENVIRONMENT=production）
+- Supabase PostgreSQL に Alembic マイグレーション実行
+
+### 3. OTP2 Server デプロイ（§7）
+- git lfs pull で graph.obj (677MB) をダウンロード
+- Cloud Buildでイメージビルド＆プッシュ
+- Cloud Run にデプロイ（**6Gi**/2CPU — 4Giではメモリ不足）
+- startup-probe 設定（failureThreshold=30, 約330秒の猶予）
+
+### 4. サービス間通信設定（§8）
+- OTP2の内部URLをSecret Managerに設定
+- fastapi-sa に OTP2 invoker 権限付与
+- FastAPI 再デプロイ
+
+## 実装箇所（コード修正）
+- `backend/alembic/env.py` — DATABASE_URL の `%` エスケープ修正（ConfigParser互換性）
+- `backend/app/services/otp2_client.py` — IDトークンの audience をベースURL（パスなし）に修正
+- `infra/cloudbuild-backend.yaml` — DATABASE_URL シークレット追加、ENVIRONMENT=production 追加
+
+## デプロイ中に発覚した問題と対応
+| 問題 | 原因 | 対応 |
+|------|------|------|
+| OTP2 デプロイ失敗（メモリ不足） | 4GiではJVMヒープ3G+オーバーヘッドが収まらない | 6Giに増量 |
+| FastAPI register 500エラー | DATABASE_URLが未設定 | Secret Managerに追加 |
+| FastAPI register テーブルなしエラー | Alembicマイグレーション未実行 | Dockerコンテナ経由でマイグレーション実行 |
+| Alembic `%` エスケープエラー | ConfigParserが `%` を特殊文字として解釈 | `.replace("%", "%%")` 修正 |
+| OTP2 404エラー（Page not found） | Cloud Run `internal` ingress でfastapi→OTP2通信が到達不可 | `ingress=all` に変更 |
+| OTP2 IDトークン認証エラー | audience にパス付きURLを渡していた | ベースURLのみに修正 |
+
+## テスト結果
+41エンドポイントをcurlでテスト:
+- **39/41 成功** ✅
+- Routes API (2件): OTP2通信成功、GTFSデータ期限切れで結果なし ⚠️
+- Suggestions API (2件): Vertex AI (Gemini) NotFoundエラー ⚠️
+
+## 残課題
+- GTFSデータ更新（経路探索で結果が返るようにする）
+- Vertex AI Gemini モデルのアクセス権限確認
+- OTP2 ingress を `internal` に戻す（VPCコネクタ設定等の検討）
+- Cloud Build CI/CDトリガー作成（§9）

--- a/backend/docs/tasks/開発タスク.md
+++ b/backend/docs/tasks/開発タスク.md
@@ -58,19 +58,22 @@
 > Phase 2（backend 実装）と並行して進める。初回デプロイに必要な最小セット（§1〜8）を優先。
 > 1人体制なら順番に、複数人なら並行実施可能。
 
-### GCP初期セットアップ（初回のみ）
+### GCP初期セットアップ（初回のみ）— ✅ 2026-03-14 完了
 
-- [ ] 🔴 GCPプロジェクト作成・請求先リンク・デフォルトリージョン設定（§1）
-- [ ] 🔴 必要なAPI有効化（Cloud Run / Cloud Build / Artifact Registry / Secret Manager 等）（§2）
-- [ ] 🔴 サービスアカウント作成（fastapi-sa, otp2-sa）+ Cloud Build SAへの権限付与（§3）
-- [ ] 🔴 Artifact Registry Docker リポジトリ作成（§4）
-- [ ] 🔴 Secret Manager にシークレット作成（6個）・fastapi-sa にアクセス権付与（§5）
+- [x] 🔴 GCPプロジェクト作成・請求先リンク・デフォルトリージョン設定（§1）— PROJECT_ID: `schedule-t-y-k-app`
+- [x] 🔴 必要なAPI有効化（Cloud Run / Cloud Build / Artifact Registry / Secret Manager / Vertex AI）（§2）
+- [x] 🔴 サービスアカウント作成（fastapi-sa, otp2-sa）+ Cloud Build SAへの権限付与（§3）
+- [x] 🔴 Artifact Registry Docker リポジトリ作成（§4）— リポジトリ名: `app`
+- [x] 🔴 Secret Manager にシークレット作成（6個）・fastapi-sa にアクセス権付与（§5）
+      作成済み: SUPABASE_URL, SUPABASE_KEY, JWT_SECRET, WEATHERAPI_KEY, OTP2_GRAPHQL_URL, DATABASE_URL
 
-### デプロイ（backend実装後）
+### デプロイ — ✅ 2026-03-14 完了
 
-- [ ] 🔴 FastAPI Backend の初回デプロイ（§6）
-- [ ] 🔴 OTP2 Server の初回デプロイ（§7）
-- [ ] 🔴 OTP2 内部URL を Secret Manager に設定 + fastapi-sa に invoker 権限付与（§8）
+- [x] 🔴 FastAPI Backend の初回デプロイ（§6）— `fastapi-backend-825512055944.asia-northeast1.run.app`
+      ENVIRONMENT=production, 512Mi/1CPU, Supabase DB マイグレーション実行済み
+- [x] 🔴 OTP2 Server の初回デプロイ（§7）— `otp2-server-sblbbag7rq-an.a.run.app`
+      6Gi/2CPU（4Giではメモリ不足のため増量）、startup-probe設定済み
+- [x] 🔴 OTP2 内部URL を Secret Manager に設定 + fastapi-sa に invoker 権限付与（§8）
 - [ ] 🟡 Cloud Build CI/CDトリガー作成（GitHub接続 + backend/otp2トリガー）（§9）
 
 ### その他（ハッカソン後半）
@@ -78,6 +81,14 @@
 - [ ] 🟡 Firebase プロジェクト追加 + iOS APNs設定（§11）
 - [ ] 🟡 モニタリング・アラート設定（OTP2メモリ80%超アラート等）（§12）
 - [ ] 🟢 予算アラート設定（$60/月）（§13）
+
+### デプロイ時の補足事項・残課題
+
+- OTP2 ingress を `all` に変更（Cloud Run間の `internal` 通信でfastapi→OTP2が404になる問題の暫定対応）
+- `otp2_client.py`: IDトークンの audience をベースURLのみに修正
+- `alembic/env.py`: DATABASE_URL の `%` エスケープ修正
+- ⚠️ Routes API: OTP2通信は成功するが、GTFSデータの有効期限切れで経路結果なし → GTFS更新が必要
+- ⚠️ Suggestions API: Vertex AI (Gemini) で `NotFound` エラー → モデルアクセス権限の確認が必要
 
 ---
 

--- a/infra/cloudbuild-backend.yaml
+++ b/infra/cloudbuild-backend.yaml
@@ -32,8 +32,8 @@ steps:
       - '--port=8000'
       - '--ingress=all'
       - '--allow-unauthenticated'
-      - '--set-secrets=SUPABASE_URL=SUPABASE_URL:latest,SUPABASE_KEY=SUPABASE_KEY:latest,JWT_SECRET=JWT_SECRET:latest,WEATHERAPI_KEY=WEATHERAPI_KEY:latest,OTP2_GRAPHQL_URL=OTP2_GRAPHQL_URL:latest'
-      - '--set-env-vars=GCP_PROJECT_ID=$PROJECT_ID,GCP_LOCATION=asia-northeast1'
+      - '--set-secrets=SUPABASE_URL=SUPABASE_URL:latest,SUPABASE_KEY=SUPABASE_KEY:latest,JWT_SECRET=JWT_SECRET:latest,WEATHERAPI_KEY=WEATHERAPI_KEY:latest,OTP2_GRAPHQL_URL=OTP2_GRAPHQL_URL:latest,DATABASE_URL=DATABASE_URL:latest'
+      - '--set-env-vars=GCP_PROJECT_ID=$PROJECT_ID,GCP_LOCATION=asia-northeast1,ENVIRONMENT=production'
       - '--service-account=fastapi-sa@$PROJECT_ID.iam.gserviceaccount.com'
       - '--timeout=60'
 

--- a/infra/docs/インフラ構築手順書.md
+++ b/infra/docs/インフラ構築手順書.md
@@ -52,7 +52,7 @@
 
 ```bash
 # プロジェクトID（一意な名前を設定）
-export PROJECT_ID="tenichi-hackathon"
+export PROJECT_ID="schedule-t-y-k-app"
 
 # リージョン
 export REGION="asia-northeast1"
@@ -268,6 +268,11 @@ echo -n "your-weather-api-key" | \
 # OTP2_GRAPHQL_URL（後で Cloud Run の内部URLに更新する）
 echo -n "placeholder" | \
   gcloud secrets create OTP2_GRAPHQL_URL --data-file=-
+
+# DATABASE_URL（Supabase PostgreSQL 接続文字列）
+# パスワードの特殊文字（*, /, %, @）はURLエンコードすること
+echo -n "postgresql+asyncpg://postgres:ENCODED_PASSWORD@db.xxxxx.supabase.co:5432/postgres" | \
+  gcloud secrets create DATABASE_URL --data-file=-
 ```
 
 > **注意:** `echo -n` の `-n` オプションで末尾の改行を除去すること。
@@ -275,7 +280,7 @@ echo -n "placeholder" | \
 ### 5.2 FastAPI サービスアカウントにシークレットアクセス権を付与
 
 ```bash
-for SECRET in SUPABASE_URL SUPABASE_KEY JWT_SECRET WEATHERAPI_KEY OTP2_GRAPHQL_URL; do
+for SECRET in SUPABASE_URL SUPABASE_KEY JWT_SECRET WEATHERAPI_KEY OTP2_GRAPHQL_URL DATABASE_URL; do
   gcloud secrets add-iam-policy-binding $SECRET \
     --member="serviceAccount:fastapi-sa@${PROJECT_ID}.iam.gserviceaccount.com" \
     --role="roles/secretmanager.secretAccessor"
@@ -288,7 +293,7 @@ done
 # シークレット一覧
 gcloud secrets list
 
-# 期待される出力（5つ）:
+# 期待される出力（6つ）:
 # NAME             CREATED              ...
 # SUPABASE_URL     2026-03-05T...       ...
 # SUPABASE_KEY     2026-03-05T...       ...
@@ -342,8 +347,8 @@ gcloud run deploy fastapi-backend \
   --port=8000 \
   --ingress=all \
   --allow-unauthenticated \
-  --set-secrets=SUPABASE_URL=SUPABASE_URL:latest,SUPABASE_KEY=SUPABASE_KEY:latest,JWT_SECRET=JWT_SECRET:latest,WEATHERAPI_KEY=WEATHERAPI_KEY:latest,OTP2_GRAPHQL_URL=OTP2_GRAPHQL_URL:latest \
-  --set-env-vars=GCP_PROJECT_ID=$PROJECT_ID,GCP_LOCATION=$REGION \
+  --set-secrets=SUPABASE_URL=SUPABASE_URL:latest,SUPABASE_KEY=SUPABASE_KEY:latest,JWT_SECRET=JWT_SECRET:latest,WEATHERAPI_KEY=WEATHERAPI_KEY:latest,OTP2_GRAPHQL_URL=OTP2_GRAPHQL_URL:latest,DATABASE_URL=DATABASE_URL:latest \
+  --set-env-vars=GCP_PROJECT_ID=$PROJECT_ID,GCP_LOCATION=$REGION,ENVIRONMENT=production \
   --service-account=fastapi-sa@${PROJECT_ID}.iam.gserviceaccount.com \
   --timeout=60
 ```
@@ -404,15 +409,17 @@ gcloud builds submit ./otp2 \
 gcloud run deploy otp2-server \
   --image=${REGION}-docker.pkg.dev/${PROJECT_ID}/${AR_REPO}/otp2-server:v1 \
   --region=$REGION \
-  --memory=4Gi \
+  --memory=6Gi \
   --cpu=2 \
   --min-instances=1 \
   --max-instances=2 \
   --port=8080 \
-  --ingress=internal \
+  --ingress=all \
   --no-allow-unauthenticated \
   --service-account=otp2-sa@${PROJECT_ID}.iam.gserviceaccount.com \
-  --timeout=300
+  --timeout=300 \
+  --cpu-boost \
+  --startup-probe=httpGet.path=/otp/,httpGet.port=8080,initialDelaySeconds=30,periodSeconds=10,timeoutSeconds=5,failureThreshold=30
 ```
 
 ### 7.4 デプロイ確認
@@ -461,8 +468,8 @@ gcloud run services add-iam-policy-binding otp2-server \
 # 新しいリビジョンを作成してシークレットの最新バージョンを反映
 gcloud run services update fastapi-backend \
   --region=$REGION \
-  --set-secrets=SUPABASE_URL=SUPABASE_URL:latest,SUPABASE_KEY=SUPABASE_KEY:latest,JWT_SECRET=JWT_SECRET:latest,WEATHERAPI_KEY=WEATHERAPI_KEY:latest,OTP2_GRAPHQL_URL=OTP2_GRAPHQL_URL:latest \
-  --set-env-vars=GCP_PROJECT_ID=$PROJECT_ID,GCP_LOCATION=$REGION
+  --set-secrets=SUPABASE_URL=SUPABASE_URL:latest,SUPABASE_KEY=SUPABASE_KEY:latest,JWT_SECRET=JWT_SECRET:latest,WEATHERAPI_KEY=WEATHERAPI_KEY:latest,OTP2_GRAPHQL_URL=OTP2_GRAPHQL_URL:latest,DATABASE_URL=DATABASE_URL:latest \
+  --set-env-vars=GCP_PROJECT_ID=$PROJECT_ID,GCP_LOCATION=$REGION,ENVIRONMENT=production
 ```
 
 ### 確認
@@ -741,6 +748,8 @@ gcloud billing budgets create \
 | `GCP_PROJECT_ID` | fastapi-backend | 環境変数 | GCP プロジェクトID（Vertex AI用） |
 | `GCP_LOCATION` | fastapi-backend | 環境変数 | GCP リージョン（デフォルト: asia-northeast1） |
 | `OTP2_GRAPHQL_URL` | fastapi-backend | Secret Manager | OTP2 内部URL + パス |
+| `DATABASE_URL` | fastapi-backend | Secret Manager | Supabase PostgreSQL 接続文字列 |
+| `ENVIRONMENT` | fastapi-backend | 環境変数 | `production`（本番）/ `development`（ローカル） |
 
 ### 付録B: トラブルシューティング
 
@@ -826,18 +835,18 @@ gcloud iam service-accounts delete otp2-sa@${PROJECT_ID}.iam.gserviceaccount.com
 
 | # | 手順 | 状態 |
 |---|------|------|
-| 1 | GCPプロジェクト作成 | ☐ |
-| 2 | 請求先アカウントリンク | ☐ |
-| 3 | API有効化 | ☐ |
-| 4 | サービスアカウント作成 (fastapi-sa, otp2-sa) | ☐ |
-| 5 | Cloud Build SA に権限付与 | ☐ |
-| 6 | Artifact Registry 作成 | ☐ |
-| 7 | Secret Manager にシークレット作成 (5個) | ☐ |
-| 8 | FastAPI Backend デプロイ | ☐ |
-| 9 | OTP2 Server デプロイ | ☐ |
-| 10 | OTP2 内部URL を Secret Manager に設定 | ☐ |
-| 11 | fastapi-sa に OTP2 invoker 権限付与 | ☐ |
-| 12 | FastAPI 再デプロイ（シークレット更新反映） | ☐ |
+| 1 | GCPプロジェクト作成 | ☑ 2026-03-14 |
+| 2 | 請求先アカウントリンク | ☑ 2026-03-14 |
+| 3 | API有効化 | ☑ 2026-03-14 |
+| 4 | サービスアカウント作成 (fastapi-sa, otp2-sa) | ☑ 2026-03-14 |
+| 5 | Cloud Build SA に権限付与 | ☑ 2026-03-14 |
+| 6 | Artifact Registry 作成 | ☑ 2026-03-14 |
+| 7 | Secret Manager にシークレット作成 (6個) | ☑ 2026-03-14 |
+| 8 | FastAPI Backend デプロイ | ☑ 2026-03-14 |
+| 9 | OTP2 Server デプロイ (6Gi) | ☑ 2026-03-14 |
+| 10 | OTP2 内部URL を Secret Manager に設定 | ☑ 2026-03-14 |
+| 11 | fastapi-sa に OTP2 invoker 権限付与 | ☑ 2026-03-14 |
+| 12 | FastAPI 再デプロイ（シークレット更新反映） | ☑ 2026-03-14 |
 | 13 | GitHub 接続 + Cloud Build トリガー作成 | ☐ |
 | 14 | Firebase プロジェクト追加 + APNs 設定 | ☐ |
 | 15 | モニタリング・アラート設定 | ☐ |


### PR DESCRIPTION
## Summary
- GCP Cloud Run 初回デプロイ時に発覚した問題のコード修正
- デプロイ結果をドキュメント（開発タスク、インフラ構築手順書）に反映
- デプロイチケット作成

## 変更内容
### コード修正
- `backend/alembic/env.py`: DATABASE_URL の `%` エスケープ修正（ConfigParser互換性）
- `backend/app/services/otp2_client.py`: IDトークンの audience をベースURL（パスなし）に修正
- `infra/cloudbuild-backend.yaml`: DATABASE_URL シークレット追加、ENVIRONMENT=production 追加

### ドキュメント更新
- `infra/docs/インフラ構築手順書.md`: PROJECT_ID修正、OTP2メモリ6Gi化、ingress=all、DATABASE_URL追加、付録A・D更新
- `backend/docs/tasks/開発タスク.md`: Phase 1 インフラチェックリストを完了済みに更新、残課題追記
- `backend/docs/tasks/tikcets/gcp-initial-deploy.md`: デプロイチケット新規作成

## 関連Issue
- #40 Suggestions API: Vertex AI NotFound エラー
- #41 Routes API: GTFSデータ期限切れ

## Test plan
- [x] `ruff check .` — All checks passed
- [x] `ruff format --check .` — 79 files already formatted
- [x] 重複ファイル（" 2" 付き）102個削除済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)