### PR TITLE
【develop】fix: Gemini モデルを gemini-2.5-flash に更新（issue #40）

### DIFF
--- a/backend/app/services/gemini_service.py
+++ b/backend/app/services/gemini_service.py
@@ -10,7 +10,7 @@ from app.exceptions import AppError
 
 logger = logging.getLogger(__name__)
 
-GEMINI_MODEL = "gemini-2.0-flash"
+GEMINI_MODEL = "gemini-2.5-flash"
 MAX_INPUT_LENGTH = 2000
 
 _client: genai.Client | None = None


### PR DESCRIPTION
gemini-2.0-flash が Vertex AI で利用不可（404 NOT_FOUND）のため gemini-2.5-flash に変更。asia-northeast1 での動作確認済み。