### PR TITLE
【develop】hotfix: OTP2 GTFS期限切れ修正 & ingress=all 暫定対応

### DIFF
--- a/backend/docs/tasks/tikcets/fix-otp2-gtfs-expired.md
+++ b/backend/docs/tasks/tikcets/fix-otp2-gtfs-expired.md
@@ -1,0 +1,46 @@
+# OTP2 GTFSデータ期限切れ修正（Issue #41）
+
+## 背景
+Cloud Run デプロイ後、Routes API で OTP2 との通信は成功するが、経路検索結果が0件で返る問題が発生。
+OTP2 の graph.obj に含まれる GTFS データの有効期限（end_date: 20251231）が切れていたことが原因。
+
+## 作業内容
+
+### 1. GTFSデータの確認
+- `learn-OpenTripPlanner/data/` 内の全22社GTFSデータの end_date を確認
+- 全社 end_date=20261231 に更新済みであることを確認
+
+### 2. graph.obj 再ビルド
+- ローカルにJavaがないため、Docker（eclipse-temurin:21-jre）でビルド
+- メモリ: Docker 10GB割当、コンテナ8GB、JVMヒープ6GB
+- data/ 内の重複サブディレクトリ（GTFS-data, json-data）を退避してビルド成功（39分）
+- 出力: graph.obj 710.1MB
+
+### 3. GCSアップロード & Cloud Buildデプロイ
+- `gsutil cp` で `gs://schedule-t-y-k-app_cloudbuild/otp2-data/graph.obj` にアップロード
+- `gcloud builds submit` で Cloud Build を手動トリガー → デプロイ成功
+
+### 4. ingress問題の発見と暫定対応
+- OTP2 の `ingress=internal` では FastAPI バックエンドからアクセスできない問題を発見
+- 原因: バックエンドに VPC egress が未設定のため、パブリック経由の通信が internal で拒否される
+- 暫定対応: `ingress=all` に変更（IAM認証で保護されているため許容）
+- Issue #54 として起票済み
+
+## 実装箇所
+- `infra/cloudbuild-otp2.yaml` — `--ingress=internal` → `--ingress=all`
+- OTP2 Docker イメージ再ビルド（graph.obj 更新）
+- GCS: `gs://schedule-t-y-k-app_cloudbuild/otp2-data/graph.obj` 更新
+
+## テスト結果
+
+### 経路検索API ✅
+```bash
+curl -X POST ".../api/v1/routes/search" \
+  -d '{"origin_lat":35.658,"origin_lon":139.7016,
+       "destination_lat":35.6812,"destination_lon":139.7671,
+       "travel_mode":"transit","arrival_time":"2026-03-20T09:00:00+09:00"}'
+```
+→ 渋谷→新宿（埼京線・川越線）→東京（中央線快速）のルートが正常に返却 ✅
+
+## 残課題
+- Issue #54: Direct VPC Egress 導入で ingress=internal に戻す（余力があれば対応）

--- a/backend/docs/tasks/tikcets/otp2-direct-vpc-egress.md
+++ b/backend/docs/tasks/tikcets/otp2-direct-vpc-egress.md
@@ -1,0 +1,52 @@
+# OTP2 Direct VPC Egress 導入（Issue #54）
+
+## 背景
+OTP2 Cloud Run の `ingress=internal` 設定時、FastAPI バックエンドからのリクエストが GFE 404 で拒否される。
+バックエンドに VPC egress が未設定のため、OTP2 へのリクエストがパブリック経由となり internal でブロックされる。
+現在は暫定対応として `ingress=all`（IAM認証あり）で運用中。
+
+## 作業内容
+
+### 1. Direct VPC Egress の設定
+FastAPI バックエンドの Cloud Run サービスに Direct VPC Egress を設定する。
+VPC Connector と異なり追加コンピュートコスト不要、同一リージョン内通信は無料。
+
+```bash
+# バックエンドに Direct VPC egress を設定
+gcloud run services update fastapi-backend \
+  --region=asia-northeast1 \
+  --network=default \
+  --subnet=default \
+  --vpc-egress=private-ranges-only
+```
+
+### 2. OTP2 の ingress を internal に戻す
+```bash
+gcloud run services update otp2-server \
+  --region=asia-northeast1 \
+  --ingress=internal
+```
+
+### 3. cloudbuild-otp2.yaml の修正
+`--ingress=all` → `--ingress=internal` に戻す
+
+### 4. cloudbuild-backend.yaml の修正
+Direct VPC egress の設定を追加:
+```yaml
+- '--network=default'
+- '--subnet=default'
+- '--vpc-egress=private-ranges-only'
+```
+
+## 実装箇所
+- `infra/cloudbuild-backend.yaml` — Direct VPC egress パラメータ追加
+- `infra/cloudbuild-otp2.yaml` — `--ingress=all` → `--ingress=internal`
+
+## テスト方法
+1. バックエンドに Direct VPC egress 設定後、OTP2 を ingress=internal に戻す
+2. 経路検索 API (`POST /api/v1/routes/search`) で結果が返ることを確認
+3. OTP2 にパブリックからアクセスできないことを確認（403/404）
+
+## 参考
+- [Direct VPC egress ドキュメント](https://docs.google.com/run/docs/configuring/vpc-direct-vpc)
+- [VPC Connector との比較](https://docs.google.com/run/docs/configuring/connecting-vpc)

--- a/backend/docs/tasks/開発タスク.md
+++ b/backend/docs/tasks/開発タスク.md
@@ -87,8 +87,11 @@
 - OTP2 ingress を `all` に変更（Cloud Run間の `internal` 通信でfastapi→OTP2が404になる問題の暫定対応）
 - `otp2_client.py`: IDトークンの audience をベースURLのみに修正
 - `alembic/env.py`: DATABASE_URL の `%` エスケープ修正
-- ⚠️ Routes API: OTP2通信は成功するが、GTFSデータの有効期限切れで経路結果なし → GTFS更新が必要
+- ~~⚠️ Routes API: OTP2通信は成功するが、GTFSデータの有効期限切れで経路結果なし → GTFS更新が必要~~ → ✅ 2026-03-15 解決（Issue #41）
+  - GTFSデータ更新（end_date: 20261231）で graph.obj を再ビルド・再デプロイ済み
+  - 経路検索API動作確認済み（渋谷→東京 等）
 - ⚠️ Suggestions API: Vertex AI (Gemini) で `NotFound` エラー → モデルアクセス権限の確認が必要
+- ⚠️ OTP2 ingress=internal でバックエンドからアクセス不可（Issue #54）→ 暫定対応: ingress=all、恒久対応: Direct VPC Egress 導入（余力があれば対応）
 
 ---
 

--- a/infra/cloudbuild-otp2.yaml
+++ b/infra/cloudbuild-otp2.yaml
@@ -36,7 +36,7 @@ steps:
       - '--min-instances=1'
       - '--max-instances=2'
       - '--port=8080'
-      - '--ingress=internal'
+      - '--ingress=all'
       - '--no-allow-unauthenticated'
       - '--service-account=otp2-sa@$PROJECT_ID.iam.gserviceaccount.com'
       - '--timeout=300'


### PR DESCRIPTION
## Summary
- OTP2 の graph.obj を新GTFSデータ（end_date: 20261231）で再ビルド・GCS更新・Cloud Runデプロイ済み（Issue #41）
- `cloudbuild-otp2.yaml` の ingress を `internal` → `all` に変更（VPC egress未設定による暫定対応、Issue #54）
- 作業チケット・開発タスク記録を追加

## Test plan
- [x] 経路検索API (`POST /api/v1/routes/search`) で渋谷→東京のルートが正常に返却されることを確認済み
- [x] OTP2 Cloud Run リビジョン正常起動確認済み
- [x] graph.obj 再ビルド成功（GTFSデータ end_date: 20261231、39分）

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)