### PR TITLE
feat: Figmaデザインに基づくホーム画面・カレンダー画面を実装

### DIFF
--- a/frontend/app/(tabs)/_layout.tsx
+++ b/frontend/app/(tabs)/_layout.tsx
@@ -21,17 +21,14 @@ export default function TabLayout() {
           fontSize: 12.25,
           fontWeight: '500',
         },
-      }}>
+      }}
+    >
       <Tabs.Screen
         name="index"
         options={{
           title: '本日の予定',
           tabBarIcon: ({ color, focused }) => (
-            <Ionicons
-              name={focused ? 'calendar' : 'calendar-outline'}
-              size={24}
-              color={color}
-            />
+            <Ionicons name={focused ? 'calendar' : 'calendar-outline'} size={24} color={color} />
           ),
           tabBarLabelStyle: {
             fontSize: 12.25,
@@ -43,9 +40,7 @@ export default function TabLayout() {
         name="calendar"
         options={{
           title: 'カレンダー',
-          tabBarIcon: ({ color }) => (
-            <Ionicons name="calendar-outline" size={24} color={color} />
-          ),
+          tabBarIcon: ({ color }) => <Ionicons name="calendar-outline" size={24} color={color} />,
         }}
       />
       <Tabs.Screen
@@ -61,9 +56,7 @@ export default function TabLayout() {
         name="mypage"
         options={{
           title: 'マイページ',
-          tabBarIcon: ({ color }) => (
-            <Ionicons name="person-outline" size={24} color={color} />
-          ),
+          tabBarIcon: ({ color }) => <Ionicons name="person-outline" size={24} color={color} />,
         }}
       />
       <Tabs.Screen

--- a/frontend/app/(tabs)/_layout.tsx
+++ b/frontend/app/(tabs)/_layout.tsx
@@ -2,33 +2,74 @@ import { Tabs } from 'expo-router';
 import React from 'react';
 
 import { HapticTab } from '@/components/haptic-tab';
-import { IconSymbol } from '@/components/ui/icon-symbol';
-import { Colors } from '@/constants/theme';
-import { useColorScheme } from '@/hooks/use-color-scheme';
+import { Ionicons, MaterialCommunityIcons } from '@expo/vector-icons';
 
 export default function TabLayout() {
-  const colorScheme = useColorScheme();
-
   return (
     <Tabs
       screenOptions={{
-        tabBarActiveTintColor: Colors[colorScheme ?? 'light'].tint,
+        tabBarActiveTintColor: '#436F9B',
+        tabBarInactiveTintColor: '#63747E',
         headerShown: false,
         tabBarButton: HapticTab,
-      }}
-    >
+        tabBarStyle: {
+          borderTopWidth: 1,
+          borderTopColor: '#EEF0F1',
+          backgroundColor: '#FFFFFF',
+        },
+        tabBarLabelStyle: {
+          fontSize: 12.25,
+          fontWeight: '500',
+        },
+      }}>
       <Tabs.Screen
         name="index"
         options={{
-          title: 'Home',
-          tabBarIcon: ({ color }) => <IconSymbol size={28} name="house.fill" color={color} />,
+          title: '本日の予定',
+          tabBarIcon: ({ color, focused }) => (
+            <Ionicons
+              name={focused ? 'calendar' : 'calendar-outline'}
+              size={24}
+              color={color}
+            />
+          ),
+          tabBarLabelStyle: {
+            fontSize: 12.25,
+            fontWeight: '700',
+          },
+        }}
+      />
+      <Tabs.Screen
+        name="calendar"
+        options={{
+          title: 'カレンダー',
+          tabBarIcon: ({ color }) => (
+            <Ionicons name="calendar-outline" size={24} color={color} />
+          ),
+        }}
+      />
+      <Tabs.Screen
+        name="routine"
+        options={{
+          title: 'ルーティン',
+          tabBarIcon: ({ color }) => (
+            <MaterialCommunityIcons name="arrow-u-left-top" size={24} color={color} />
+          ),
+        }}
+      />
+      <Tabs.Screen
+        name="mypage"
+        options={{
+          title: 'マイページ',
+          tabBarIcon: ({ color }) => (
+            <Ionicons name="person-outline" size={24} color={color} />
+          ),
         }}
       />
       <Tabs.Screen
         name="explore"
         options={{
-          title: 'Explore',
-          tabBarIcon: ({ color }) => <IconSymbol size={28} name="paperplane.fill" color={color} />,
+          href: null,
         }}
       />
     </Tabs>

--- a/frontend/app/(tabs)/calendar.tsx
+++ b/frontend/app/(tabs)/calendar.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+
+export default function CalendarScreen() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.text}>カレンダー</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: '#FFFFFF',
+  },
+  text: {
+    fontSize: 17.5,
+    fontWeight: '700',
+    color: '#1F2528',
+  },
+});

--- a/frontend/app/(tabs)/calendar.tsx
+++ b/frontend/app/(tabs)/calendar.tsx
@@ -1,10 +1,153 @@
-import React from 'react';
-import { StyleSheet, Text, View } from 'react-native';
+import React, { useState } from 'react';
+import {
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { Ionicons } from '@expo/vector-icons';
+
+const C = {
+  primary: '#436F9B',
+  accent: '#6E8F8A',
+  textPrimary: '#1F2528',
+  textSecondary: '#63747E',
+  textMuted: '#B5BFC5',
+  white: '#FFFFFF',
+  border: '#EEF0F1',
+  black: '#000000',
+};
+
+const WEEKDAYS = ['日', '月', '火', '水', '木', '金', '土'];
+
+// Mock events: day -> label
+const EVENTS: Record<number, string> = {
+  3: '仕事の日',
+  10: '休日',
+  17: '仕事の日',
+  25: '出張',
+};
+
+function getCalendarDays(year: number, month: number) {
+  const firstDay = new Date(year, month, 1).getDay();
+  const daysInMonth = new Date(year, month + 1, 0).getDate();
+  const daysInPrevMonth = new Date(year, month, 0).getDate();
+
+  const days: { day: number; currentMonth: boolean }[] = [];
+
+  // Previous month trailing days
+  for (let i = firstDay - 1; i >= 0; i--) {
+    days.push({ day: daysInPrevMonth - i, currentMonth: false });
+  }
+
+  // Current month
+  for (let i = 1; i <= daysInMonth; i++) {
+    days.push({ day: i, currentMonth: true });
+  }
+
+  // Next month leading days (fill to 6 rows)
+  const remaining = 42 - days.length;
+  for (let i = 1; i <= remaining; i++) {
+    days.push({ day: i, currentMonth: false });
+  }
+
+  return days;
+}
 
 export default function CalendarScreen() {
+  const insets = useSafeAreaInsets();
+  const [selectedDay, setSelectedDay] = useState(3);
+  const year = 2025;
+  const month = 2; // March (0-indexed)
+
+  const days = getCalendarDays(year, month);
+  const weeks: (typeof days)[] = [];
+  for (let i = 0; i < days.length; i += 7) {
+    weeks.push(days.slice(i, i + 7));
+  }
+
   return (
     <View style={styles.container}>
-      <Text style={styles.text}>カレンダー</Text>
+      {/* Header */}
+      <View style={[styles.header, { paddingTop: insets.top }]}>
+        <TouchableOpacity style={styles.monthSelector}>
+          <Text style={styles.monthText}>3月</Text>
+          <Ionicons
+            name="caret-down"
+            size={12}
+            color={C.textPrimary}
+          />
+        </TouchableOpacity>
+      </View>
+
+      <ScrollView
+        style={styles.scrollView}
+        contentContainerStyle={styles.scrollContent}
+        showsVerticalScrollIndicator={false}
+      >
+        {/* Weekday headers */}
+        <View style={styles.weekdayRow}>
+          {WEEKDAYS.map((d) => (
+            <View key={d} style={styles.weekdayCell}>
+              <Text style={styles.weekdayText}>{d}</Text>
+            </View>
+          ))}
+        </View>
+
+        {/* Calendar grid */}
+        {weeks.map((week, wi) => (
+          <View key={wi} style={styles.weekRow}>
+            {week.map((item, di) => {
+              const isSelected =
+                item.currentMonth && item.day === selectedDay;
+              const event =
+                item.currentMonth ? EVENTS[item.day] : undefined;
+
+              return (
+                <TouchableOpacity
+                  key={`${wi}-${di}`}
+                  style={styles.dayCell}
+                  onPress={() => {
+                    if (item.currentMonth) setSelectedDay(item.day);
+                  }}
+                  activeOpacity={item.currentMonth ? 0.6 : 1}
+                >
+                  {isSelected ? (
+                    <View style={styles.selectedCircle}>
+                      <Text style={styles.selectedDayText}>
+                        {item.day}
+                      </Text>
+                    </View>
+                  ) : (
+                    <Text
+                      style={[
+                        styles.dayText,
+                        !item.currentMonth && styles.dayTextMuted,
+                      ]}
+                    >
+                      {item.day}
+                    </Text>
+                  )}
+                  {event && (
+                    <View style={styles.eventBadge}>
+                      <Text style={styles.eventBadgeText}>{event}</Text>
+                    </View>
+                  )}
+                </TouchableOpacity>
+              );
+            })}
+          </View>
+        ))}
+      </ScrollView>
+
+      {/* FAB */}
+      <TouchableOpacity
+        style={[styles.fab, { bottom: 100 + insets.bottom }]}
+      >
+        <Ionicons name="add" size={28} color={C.white} />
+      </TouchableOpacity>
     </View>
   );
 }
@@ -12,13 +155,121 @@ export default function CalendarScreen() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    alignItems: 'center',
-    justifyContent: 'center',
-    backgroundColor: '#FFFFFF',
+    backgroundColor: C.white,
   },
-  text: {
+
+  // Header
+  header: {
+    backgroundColor: C.white,
+    paddingHorizontal: 12.25,
+    paddingBottom: 10,
+    borderBottomWidth: 1,
+    borderBottomColor: C.border,
+    justifyContent: 'center',
+    minHeight: 56,
+  },
+  monthSelector: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 3.5,
+  },
+  monthText: {
     fontSize: 17.5,
     fontWeight: '700',
-    color: '#1F2528',
+    color: C.black,
+  },
+
+  // Scroll
+  scrollView: {
+    flex: 1,
+  },
+  scrollContent: {
+    paddingTop: 17.5,
+    paddingBottom: 100,
+  },
+
+  // Weekday header
+  weekdayRow: {
+    flexDirection: 'row',
+    gap: 3.5,
+  },
+  weekdayCell: {
+    flex: 1,
+    alignItems: 'center',
+  },
+  weekdayText: {
+    fontSize: 12.25,
+    fontWeight: '500',
+    color: C.textSecondary,
+    textAlign: 'center',
+  },
+
+  // Calendar grid
+  weekRow: {
+    flexDirection: 'row',
+    gap: 3.5,
+    marginTop: 12.25,
+  },
+  dayCell: {
+    flex: 1,
+    alignItems: 'center',
+    gap: 3.5,
+    paddingVertical: 3.5,
+  },
+  dayText: {
+    fontSize: 14,
+    fontWeight: '500',
+    color: C.textPrimary,
+    textAlign: 'center',
+    width: 24.5,
+    lineHeight: 24.5,
+  },
+  dayTextMuted: {
+    color: C.textMuted,
+  },
+  selectedCircle: {
+    width: 24.5,
+    height: 24.5,
+    borderRadius: 12.25,
+    backgroundColor: C.primary,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  selectedDayText: {
+    fontSize: 14,
+    fontWeight: '500',
+    color: C.white,
+    textAlign: 'center',
+  },
+
+  // Event badge
+  eventBadge: {
+    backgroundColor: C.accent,
+    borderRadius: 5.25,
+    paddingHorizontal: 4,
+    paddingVertical: 1.875,
+    alignSelf: 'center',
+  },
+  eventBadgeText: {
+    fontSize: 10.5,
+    fontWeight: '500',
+    color: C.white,
+  },
+
+  // FAB
+  fab: {
+    position: 'absolute',
+    right: 20,
+    width: 56,
+    height: 56,
+    borderRadius: 28,
+    backgroundColor: C.primary,
+    alignItems: 'center',
+    justifyContent: 'center',
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.24,
+    shadowRadius: 10,
+    elevation: 5,
   },
 });

--- a/frontend/app/(tabs)/calendar.tsx
+++ b/frontend/app/(tabs)/calendar.tsx
@@ -1,11 +1,5 @@
 import React, { useState } from 'react';
-import {
-  ScrollView,
-  StyleSheet,
-  Text,
-  TouchableOpacity,
-  View,
-} from 'react-native';
+import { ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
 
@@ -74,11 +68,7 @@ export default function CalendarScreen() {
       <View style={[styles.header, { paddingTop: insets.top }]}>
         <TouchableOpacity style={styles.monthSelector}>
           <Text style={styles.monthText}>3月</Text>
-          <Ionicons
-            name="caret-down"
-            size={12}
-            color={C.textPrimary}
-          />
+          <Ionicons name="caret-down" size={12} color={C.textPrimary} />
         </TouchableOpacity>
       </View>
 
@@ -89,7 +79,7 @@ export default function CalendarScreen() {
       >
         {/* Weekday headers */}
         <View style={styles.weekdayRow}>
-          {WEEKDAYS.map((d) => (
+          {WEEKDAYS.map(d => (
             <View key={d} style={styles.weekdayCell}>
               <Text style={styles.weekdayText}>{d}</Text>
             </View>
@@ -100,10 +90,8 @@ export default function CalendarScreen() {
         {weeks.map((week, wi) => (
           <View key={wi} style={styles.weekRow}>
             {week.map((item, di) => {
-              const isSelected =
-                item.currentMonth && item.day === selectedDay;
-              const event =
-                item.currentMonth ? EVENTS[item.day] : undefined;
+              const isSelected = item.currentMonth && item.day === selectedDay;
+              const event = item.currentMonth ? EVENTS[item.day] : undefined;
 
               return (
                 <TouchableOpacity
@@ -116,17 +104,10 @@ export default function CalendarScreen() {
                 >
                   {isSelected ? (
                     <View style={styles.selectedCircle}>
-                      <Text style={styles.selectedDayText}>
-                        {item.day}
-                      </Text>
+                      <Text style={styles.selectedDayText}>{item.day}</Text>
                     </View>
                   ) : (
-                    <Text
-                      style={[
-                        styles.dayText,
-                        !item.currentMonth && styles.dayTextMuted,
-                      ]}
-                    >
+                    <Text style={[styles.dayText, !item.currentMonth && styles.dayTextMuted]}>
                       {item.day}
                     </Text>
                   )}
@@ -143,9 +124,7 @@ export default function CalendarScreen() {
       </ScrollView>
 
       {/* FAB */}
-      <TouchableOpacity
-        style={[styles.fab, { bottom: 100 + insets.bottom }]}
-      >
+      <TouchableOpacity style={[styles.fab, { bottom: 100 + insets.bottom }]}>
         <Ionicons name="add" size={28} color={C.white} />
       </TouchableOpacity>
     </View>

--- a/frontend/app/(tabs)/index.tsx
+++ b/frontend/app/(tabs)/index.tsx
@@ -211,7 +211,7 @@ export default function HomeScreen() {
               style={[
                 styles.timelineLine,
                 {
-                  borderColor: item.past ? C.textMuted : C.textMuted,
+                  borderColor: C.textMuted,
                 },
               ]}
             />

--- a/frontend/app/(tabs)/index.tsx
+++ b/frontend/app/(tabs)/index.tsx
@@ -1,18 +1,7 @@
 import React from 'react';
-import {
-  ScrollView,
-  StyleSheet,
-  Text,
-  TouchableOpacity,
-  View,
-} from 'react-native';
+import { ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import {
-  Ionicons,
-  MaterialCommunityIcons,
-  Feather,
-  FontAwesome5,
-} from '@expo/vector-icons';
+import { Ionicons, MaterialCommunityIcons, Feather, FontAwesome5 } from '@expo/vector-icons';
 
 // Colors
 const C = {
@@ -120,11 +109,7 @@ export default function HomeScreen() {
       <View style={styles.todoCard}>
         {/* Todo header */}
         <View style={styles.todoHeader}>
-          <MaterialCommunityIcons
-            name="clipboard-text-outline"
-            size={24.5}
-            color={C.textPrimary}
-          />
+          <MaterialCommunityIcons name="clipboard-text-outline" size={24.5} color={C.textPrimary} />
           <Text style={styles.todoHeaderText}>本日すること！</Text>
         </View>
         {/* Todo body */}
@@ -182,10 +167,7 @@ export default function HomeScreen() {
     );
   }
 
-  function renderTimelineEntry(
-    item: (typeof TIMELINE)[number],
-    index: number
-  ) {
+  function renderTimelineEntry(item: (typeof TIMELINE)[number], index: number) {
     const isLast = index === TIMELINE.length - 1;
     const textColor = item.past ? C.textMuted : C.black;
 
@@ -193,9 +175,7 @@ export default function HomeScreen() {
       <View key={`${item.time}-${item.title}`} style={styles.timelineRow}>
         {/* Time column */}
         <View style={styles.timeColumn}>
-          <Text style={[styles.timeText, { color: textColor }]}>
-            {item.time}
-          </Text>
+          <Text style={[styles.timeText, { color: textColor }]}>{item.time}</Text>
           {/* Dot */}
           <View
             style={[
@@ -223,9 +203,7 @@ export default function HomeScreen() {
           {/* Station with badge */}
           {item.badge && (
             <View style={styles.stationRow}>
-              <Text style={[styles.stationName, { color: textColor }]}>
-                {item.title}
-              </Text>
+              <Text style={[styles.stationName, { color: textColor }]}>{item.title}</Text>
               <View style={styles.trainBadge}>
                 <Text style={styles.trainBadgeText}>{item.badge}</Text>
               </View>
@@ -235,44 +213,28 @@ export default function HomeScreen() {
           {/* Walk info */}
           {item.walk && (
             <View style={styles.stationRow}>
-              <Text style={[styles.stationName, { color: textColor }]}>
-                {item.title}
-              </Text>
-              <Text style={styles.walkText}>
-                🚶{item.walk}
-              </Text>
+              <Text style={[styles.stationName, { color: textColor }]}>{item.title}</Text>
+              <Text style={styles.walkText}>🚶{item.walk}</Text>
             </View>
           )}
 
           {/* Event with icon + chevron */}
           {item.hasChevron && (
             <TouchableOpacity style={styles.eventCard}>
-              <View
-                style={[styles.eventIcon, { backgroundColor: item.iconBg }]}
-              >
-                <Ionicons
-                  name="calendar-outline"
-                  size={18}
-                  color={C.textSecondary}
-                />
+              <View style={[styles.eventIcon, { backgroundColor: item.iconBg }]}>
+                <Ionicons name="calendar-outline" size={18} color={C.textSecondary} />
               </View>
               <View style={styles.eventDetails}>
                 <Text style={styles.eventTitle}>{item.title}</Text>
                 <Text style={styles.eventSubtitle}>{item.subtitle}</Text>
               </View>
-              <Ionicons
-                name="chevron-forward"
-                size={18}
-                color={C.textMuted}
-              />
+              <Ionicons name="chevron-forward" size={18} color={C.textMuted} />
             </TouchableOpacity>
           )}
 
           {/* Simple station (no badge, no walk, no chevron) */}
           {!item.badge && !item.walk && !item.hasChevron && (
-            <Text style={[styles.stationName, { color: textColor }]}>
-              {item.title}
-            </Text>
+            <Text style={[styles.stationName, { color: textColor }]}>{item.title}</Text>
           )}
         </View>
       </View>
@@ -280,9 +242,7 @@ export default function HomeScreen() {
   }
 
   function renderTimeline() {
-    return (
-      <View style={styles.timeline}>{TIMELINE.map(renderTimelineEntry)}</View>
-    );
+    return <View style={styles.timeline}>{TIMELINE.map(renderTimelineEntry)}</View>;
   }
 
   return (

--- a/frontend/app/(tabs)/index.tsx
+++ b/frontend/app/(tabs)/index.tsx
@@ -1,99 +1,625 @@
-import { Image } from 'expo-image';
-import { Platform, StyleSheet } from 'react-native';
+import React from 'react';
+import {
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import {
+  Ionicons,
+  MaterialCommunityIcons,
+  Feather,
+  FontAwesome5,
+} from '@expo/vector-icons';
 
-import { HelloWave } from '@/components/hello-wave';
-import ParallaxScrollView from '@/components/parallax-scroll-view';
-import { ThemedText } from '@/components/themed-text';
-import { ThemedView } from '@/components/themed-view';
-import { Link } from 'expo-router';
+// Colors
+const C = {
+  headerBg: '#436F9B',
+  todoBg: '#E6EDF6',
+  todoBorder: '#A8C0DD',
+  routineBorder: '#6E8F8A',
+  weatherBg: '#EDF0F2',
+  trainBg: '#EEF0F1',
+  eventGreen: '#EEF3F2',
+  eventWarm: '#F3EFE6',
+  textPrimary: '#1F2528',
+  textSecondary: '#63747E',
+  textMuted: '#B5BFC5',
+  black: '#000000',
+  white: '#FFFFFF',
+  trainBadgeBg: '#B5BFC5',
+  fabBg: '#436F9B',
+  warmText: '#AA8A5E',
+};
+
+// Mock data
+const TIMELINE = [
+  {
+    time: '08:34',
+    title: '荻窪発',
+    badge: '中央線快速',
+    past: true,
+  },
+  {
+    time: '08:52',
+    title: '新宿乗換',
+    badge: '山手線',
+    past: true,
+  },
+  {
+    time: '09:00',
+    title: '渋谷着',
+    walk: '12分',
+    past: false,
+  },
+  {
+    time: '09:30',
+    title: 'デザインレビュー',
+    subtitle: '渋谷オフィス4F',
+    iconBg: C.eventGreen,
+    past: false,
+    hasChevron: true,
+  },
+  {
+    time: '12:00',
+    title: 'ランチ',
+    subtitle: '恵比寿 CAFE BRISE',
+    iconBg: C.eventWarm,
+    past: false,
+    hasChevron: true,
+  },
+  {
+    time: '15:30',
+    title: 'クライアント提案',
+    subtitle: 'オンラインZoom',
+    iconBg: C.eventGreen,
+    past: false,
+    hasChevron: true,
+  },
+  {
+    time: '16:30',
+    title: 'クライアント提案',
+    subtitle: 'オンラインZoom',
+    iconBg: C.eventGreen,
+    past: false,
+    hasChevron: true,
+  },
+];
 
 export default function HomeScreen() {
-  return (
-    <ParallaxScrollView
-      headerBackgroundColor={{ light: '#A1CEDC', dark: '#1D3D47' }}
-      headerImage={
-        <Image
-          source={require('@/assets/images/partial-react-logo.png')}
-          style={styles.reactLogo}
-        />
-      }
-    >
-      <ThemedView style={styles.titleContainer}>
-        <ThemedText type="title">Welcome!</ThemedText>
-        <HelloWave />
-      </ThemedView>
-      <ThemedView style={styles.stepContainer}>
-        <ThemedText type="subtitle">Step 1: Try it</ThemedText>
-        <ThemedText>
-          Edit <ThemedText type="defaultSemiBold">app/(tabs)/index.tsx</ThemedText> to see changes.
-          Press{' '}
-          <ThemedText type="defaultSemiBold">
-            {Platform.select({
-              ios: 'cmd + d',
-              android: 'cmd + m',
-              web: 'F12',
-            })}
-          </ThemedText>{' '}
-          to open developer tools.
-        </ThemedText>
-      </ThemedView>
-      <ThemedView style={styles.stepContainer}>
-        <Link href="/modal">
-          <Link.Trigger>
-            <ThemedText type="subtitle">Step 2: Explore</ThemedText>
-          </Link.Trigger>
-          <Link.Preview />
-          <Link.Menu>
-            <Link.MenuAction title="Action" icon="cube" onPress={() => alert('Action pressed')} />
-            <Link.MenuAction
-              title="Share"
-              icon="square.and.arrow.up"
-              onPress={() => alert('Share pressed')}
-            />
-            <Link.Menu title="More" icon="ellipsis">
-              <Link.MenuAction
-                title="Delete"
-                icon="trash"
-                destructive
-                onPress={() => alert('Delete pressed')}
-              />
-            </Link.Menu>
-          </Link.Menu>
-        </Link>
+  const insets = useSafeAreaInsets();
 
-        <ThemedText>
-          {`Tap the Explore tab to learn more about what's included in this starter app.`}
-        </ThemedText>
-      </ThemedView>
-      <ThemedView style={styles.stepContainer}>
-        <ThemedText type="subtitle">Step 3: Get a fresh start</ThemedText>
-        <ThemedText>
-          {`When you're ready, run `}
-          <ThemedText type="defaultSemiBold">npm run reset-project</ThemedText> to get a fresh{' '}
-          <ThemedText type="defaultSemiBold">app</ThemedText> directory. This will move the current{' '}
-          <ThemedText type="defaultSemiBold">app</ThemedText> to{' '}
-          <ThemedText type="defaultSemiBold">app-example</ThemedText>.
-        </ThemedText>
-      </ThemedView>
-    </ParallaxScrollView>
+  function renderHeader() {
+    return (
+      <View style={[styles.header, { paddingTop: insets.top + 10 }]}>
+        <View style={styles.chatRow}>
+          {/* Avatar */}
+          <View style={styles.avatar}>
+            <Ionicons name="person" size={22} color={C.white} />
+          </View>
+          {/* Chat bubble */}
+          <View style={styles.chatBubble}>
+            <Text style={styles.chatText}>
+              おはよう！昨日はよく眠れたかな？{'\n'}
+              本日15時から降水確率70%なので、傘が必要かも！
+            </Text>
+          </View>
+        </View>
+        {/* Menu button */}
+        <TouchableOpacity style={styles.menuButton}>
+          <Feather name="more-horizontal" size={20} color={C.white} />
+        </TouchableOpacity>
+      </View>
+    );
+  }
+
+  function renderTodoCard() {
+    return (
+      <View style={styles.todoCard}>
+        {/* Todo header */}
+        <View style={styles.todoHeader}>
+          <MaterialCommunityIcons
+            name="clipboard-text-outline"
+            size={24.5}
+            color={C.textPrimary}
+          />
+          <Text style={styles.todoHeaderText}>本日すること！</Text>
+        </View>
+        {/* Todo body */}
+        <View style={styles.todoBody}>
+          {/* Checked item */}
+          <View style={styles.todoRow}>
+            <Ionicons name="checkbox" size={22} color="#4CAF50" />
+            <Text style={styles.todoCheckedText}>MTGの準備</Text>
+          </View>
+          {/* Dashed divider */}
+          <View style={styles.dashedDivider} />
+          {/* Unchecked item */}
+          <View style={styles.todoRow}>
+            <View style={styles.uncheckedBox} />
+            <Text style={styles.todoText}>スーパーで買い物</Text>
+          </View>
+        </View>
+      </View>
+    );
+  }
+
+  function renderWeatherTrainRow() {
+    return (
+      <View style={styles.weatherTrainRow}>
+        {/* Weather card */}
+        <View style={styles.weatherCard}>
+          <Ionicons name="cloud" size={23} color={C.textSecondary} />
+          <Text style={styles.weatherTemp}>18℃ / 12℃</Text>
+          <Text style={styles.weatherNote}>午後から雨</Text>
+        </View>
+        {/* Train card */}
+        <View style={styles.trainCard}>
+          <MaterialCommunityIcons name="train" size={28} color={C.textPrimary} />
+          <Text style={styles.trainTime}>09:00 渋谷着</Text>
+        </View>
+      </View>
+    );
+  }
+
+  function renderScheduleHeader() {
+    return (
+      <View style={styles.scheduleHeader}>
+        <Text style={styles.scheduleDate}>3/4 (木)</Text>
+        <Text style={styles.scheduleTitle}>本日の予定</Text>
+      </View>
+    );
+  }
+
+  function renderRoutineCard() {
+    return (
+      <View style={styles.routineCard}>
+        <FontAwesome5 name="briefcase" size={20} color={C.routineBorder} />
+        <Text style={styles.routineTitle}>仕事ルーティン①</Text>
+      </View>
+    );
+  }
+
+  function renderTimelineEntry(
+    item: (typeof TIMELINE)[number],
+    index: number
+  ) {
+    const isLast = index === TIMELINE.length - 1;
+    const textColor = item.past ? C.textMuted : C.black;
+
+    return (
+      <View key={`${item.time}-${item.title}`} style={styles.timelineRow}>
+        {/* Time column */}
+        <View style={styles.timeColumn}>
+          <Text style={[styles.timeText, { color: textColor }]}>
+            {item.time}
+          </Text>
+          {/* Dot */}
+          <View
+            style={[
+              styles.timelineDot,
+              {
+                backgroundColor: item.past ? C.textMuted : C.headerBg,
+              },
+            ]}
+          />
+          {/* Vertical line */}
+          {!isLast && (
+            <View
+              style={[
+                styles.timelineLine,
+                {
+                  borderColor: item.past ? C.textMuted : C.textMuted,
+                },
+              ]}
+            />
+          )}
+        </View>
+
+        {/* Content column */}
+        <View style={styles.timelineContent}>
+          {/* Station with badge */}
+          {item.badge && (
+            <View style={styles.stationRow}>
+              <Text style={[styles.stationName, { color: textColor }]}>
+                {item.title}
+              </Text>
+              <View style={styles.trainBadge}>
+                <Text style={styles.trainBadgeText}>{item.badge}</Text>
+              </View>
+            </View>
+          )}
+
+          {/* Walk info */}
+          {item.walk && (
+            <View style={styles.stationRow}>
+              <Text style={[styles.stationName, { color: textColor }]}>
+                {item.title}
+              </Text>
+              <Text style={styles.walkText}>
+                🚶{item.walk}
+              </Text>
+            </View>
+          )}
+
+          {/* Event with icon + chevron */}
+          {item.hasChevron && (
+            <TouchableOpacity style={styles.eventCard}>
+              <View
+                style={[styles.eventIcon, { backgroundColor: item.iconBg }]}
+              >
+                <Ionicons
+                  name="calendar-outline"
+                  size={18}
+                  color={C.textSecondary}
+                />
+              </View>
+              <View style={styles.eventDetails}>
+                <Text style={styles.eventTitle}>{item.title}</Text>
+                <Text style={styles.eventSubtitle}>{item.subtitle}</Text>
+              </View>
+              <Ionicons
+                name="chevron-forward"
+                size={18}
+                color={C.textMuted}
+              />
+            </TouchableOpacity>
+          )}
+
+          {/* Simple station (no badge, no walk, no chevron) */}
+          {!item.badge && !item.walk && !item.hasChevron && (
+            <Text style={[styles.stationName, { color: textColor }]}>
+              {item.title}
+            </Text>
+          )}
+        </View>
+      </View>
+    );
+  }
+
+  function renderTimeline() {
+    return (
+      <View style={styles.timeline}>{TIMELINE.map(renderTimelineEntry)}</View>
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      {renderHeader()}
+      <ScrollView
+        style={styles.scrollView}
+        contentContainerStyle={styles.scrollContent}
+        showsVerticalScrollIndicator={false}
+      >
+        <View style={styles.mainContent}>
+          {renderTodoCard()}
+          {renderWeatherTrainRow()}
+          {renderScheduleHeader()}
+          {renderRoutineCard()}
+          {renderTimeline()}
+        </View>
+      </ScrollView>
+
+      {/* FAB */}
+      <TouchableOpacity style={[styles.fab, { bottom: 100 + insets.bottom }]}>
+        <Ionicons name="add" size={28} color={C.white} />
+      </TouchableOpacity>
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
-  titleContainer: {
+  container: {
+    flex: 1,
+    backgroundColor: C.headerBg,
+  },
+  // Header
+  header: {
+    backgroundColor: C.headerBg,
+    paddingHorizontal: 14,
+    paddingBottom: 24.5,
+  },
+  chatRow: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: 10,
+  },
+  avatar: {
+    width: 42,
+    height: 42,
+    borderRadius: 21,
+    backgroundColor: 'rgba(255,255,255,0.3)',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  chatBubble: {
+    flex: 1,
+    backgroundColor: C.white,
+    borderTopLeftRadius: 3.5,
+    borderTopRightRadius: 10.5,
+    borderBottomLeftRadius: 10.5,
+    borderBottomRightRadius: 10.5,
+    padding: 12,
+  },
+  chatText: {
+    fontSize: 14,
+    fontWeight: '400',
+    lineHeight: 21,
+    color: C.textPrimary,
+  },
+  menuButton: {
+    position: 'absolute',
+    right: 14,
+    bottom: 32,
+    width: 35,
+    height: 35,
+    borderRadius: 17.5,
+    backgroundColor: 'rgba(26,26,26,0.3)',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+
+  // Scroll
+  scrollView: {
+    flex: 1,
+  },
+  scrollContent: {
+    paddingBottom: 100,
+  },
+
+  // Main content
+  mainContent: {
+    backgroundColor: C.white,
+    borderTopLeftRadius: 10.5,
+    borderTopRightRadius: 10.5,
+    marginTop: -8,
+    paddingHorizontal: 14,
+    paddingTop: 17.5,
+    paddingBottom: 17.5,
+    gap: 17.5,
+    minHeight: 800,
+  },
+
+  // Todo card
+  todoCard: {
+    borderWidth: 2,
+    borderColor: C.todoBorder,
+    borderRadius: 14,
+    overflow: 'hidden',
+  },
+  todoHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    backgroundColor: C.todoBg,
+    borderBottomWidth: 2,
+    borderBottomColor: C.todoBorder,
+    paddingHorizontal: 17.5,
+    paddingVertical: 12.25,
+  },
+  todoHeaderText: {
+    fontSize: 14,
+    fontWeight: '700',
+    color: C.textPrimary,
+  },
+  todoBody: {
+    paddingHorizontal: 17.5,
+    paddingVertical: 17.5,
+    gap: 17.5,
+  },
+  todoRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+  },
+  todoCheckedText: {
+    fontSize: 14,
+    fontWeight: '500',
+    color: C.textPrimary,
+    textDecorationLine: 'line-through',
+    textDecorationColor: C.textMuted,
+  },
+  todoText: {
+    fontSize: 14,
+    fontWeight: '500',
+    color: C.textPrimary,
+  },
+  uncheckedBox: {
+    width: 22,
+    height: 22,
+    borderRadius: 4,
+    borderWidth: 1,
+    borderColor: C.textMuted,
+  },
+  dashedDivider: {
+    height: 0,
+    borderBottomWidth: 1.5,
+    borderBottomColor: C.todoBorder,
+    borderStyle: 'dashed',
+  },
+
+  // Weather + Train
+  weatherTrainRow: {
+    flexDirection: 'row',
+    gap: 17.5,
+  },
+  weatherCard: {
+    flex: 1,
+    backgroundColor: C.weatherBg,
+    borderRadius: 7,
+    paddingVertical: 7,
+    paddingHorizontal: 12.25,
+    alignItems: 'center',
+    gap: 7,
+  },
+  weatherTemp: {
+    fontSize: 12.25,
+    fontWeight: '500',
+    color: C.textPrimary,
+  },
+  weatherNote: {
+    fontSize: 12.25,
+    fontWeight: '500',
+    color: C.warmText,
+  },
+  trainCard: {
+    flex: 1,
+    backgroundColor: C.trainBg,
+    borderRadius: 7,
+    paddingVertical: 7,
+    paddingHorizontal: 12.25,
+    alignItems: 'center',
+    gap: 7,
+  },
+  trainTime: {
+    fontSize: 15.75,
+    fontWeight: '500',
+    color: C.textPrimary,
+  },
+
+  // Schedule header
+  scheduleHeader: {
+    gap: 2,
+  },
+  scheduleDate: {
+    fontSize: 12.25,
+    fontWeight: '500',
+    color: C.textSecondary,
+  },
+  scheduleTitle: {
+    fontSize: 17.5,
+    fontWeight: '700',
+    color: C.black,
+  },
+
+  // Routine card
+  routineCard: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+    borderWidth: 1,
+    borderColor: C.routineBorder,
+    borderRadius: 7,
+    borderLeftWidth: 6,
+    borderLeftColor: C.routineBorder,
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+  },
+  routineTitle: {
+    fontSize: 14,
+    fontWeight: '700',
+    color: C.textPrimary,
+  },
+
+  // Timeline
+  timeline: {},
+  timelineRow: {
+    flexDirection: 'row',
+    minHeight: 56,
+  },
+  timeColumn: {
+    width: 70,
+    alignItems: 'center',
+    position: 'relative',
+  },
+  timeText: {
+    fontSize: 14,
+    fontWeight: '500',
+    marginBottom: 6,
+  },
+  timelineDot: {
+    width: 10,
+    height: 10,
+    borderRadius: 5,
+  },
+  timelineLine: {
+    position: 'absolute',
+    top: 36,
+    bottom: 0,
+    width: 0,
+    borderLeftWidth: 1.5,
+    borderStyle: 'dashed',
+  },
+  timelineContent: {
+    flex: 1,
+    paddingBottom: 14,
+    paddingLeft: 8,
+  },
+
+  // Station row
+  stationRow: {
     flexDirection: 'row',
     alignItems: 'center',
     gap: 8,
   },
-  stepContainer: {
-    gap: 8,
-    marginBottom: 8,
+  stationName: {
+    fontSize: 14,
+    fontWeight: '700',
   },
-  reactLogo: {
-    height: 178,
-    width: 290,
-    bottom: 0,
-    left: 0,
+  trainBadge: {
+    backgroundColor: C.trainBadgeBg,
+    borderRadius: 4,
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+  },
+  trainBadgeText: {
+    fontSize: 11,
+    fontWeight: '500',
+    color: C.white,
+  },
+  walkText: {
+    fontSize: 12.25,
+    fontWeight: '400',
+    color: C.textSecondary,
+    marginLeft: 4,
+  },
+
+  // Event card
+  eventCard: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+    backgroundColor: C.white,
+    borderRadius: 8,
+    paddingVertical: 4,
+  },
+  eventIcon: {
+    width: 36,
+    height: 36,
+    borderRadius: 8,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  eventDetails: {
+    flex: 1,
+  },
+  eventTitle: {
+    fontSize: 14,
+    fontWeight: '500',
+    color: C.textPrimary,
+  },
+  eventSubtitle: {
+    fontSize: 12.25,
+    fontWeight: '400',
+    color: C.textSecondary,
+  },
+
+  // FAB
+  fab: {
     position: 'absolute',
+    right: 20,
+    width: 56,
+    height: 56,
+    borderRadius: 28,
+    backgroundColor: C.fabBg,
+    alignItems: 'center',
+    justifyContent: 'center',
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.25,
+    shadowRadius: 4,
+    elevation: 5,
   },
 });

--- a/frontend/app/(tabs)/mypage.tsx
+++ b/frontend/app/(tabs)/mypage.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+
+export default function MyPageScreen() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.text}>マイページ</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: '#FFFFFF',
+  },
+  text: {
+    fontSize: 17.5,
+    fontWeight: '700',
+    color: '#1F2528',
+  },
+});

--- a/frontend/app/(tabs)/routine.tsx
+++ b/frontend/app/(tabs)/routine.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+
+export default function RoutineScreen() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.text}>ルーティン</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: '#FFFFFF',
+  },
+  text: {
+    fontSize: 17.5,
+    fontWeight: '700',
+    color: '#1F2528',
+  },
+});


### PR DESCRIPTION
## Summary
- Figmaデザインに基づき、天一アプリのホーム画面とカレンダー画面をReact Native（Expo Router）で実装
- ホーム画面: ヘッダー（AIチャットバブル）、Todoカード、天気・電車カード、タイムライン形式スケジュール、ルーティンカード、FABボタン
- カレンダー画面: 月表示カレンダーグリッド、選択日ハイライト、イベントバッジ、月選択ヘッダー
- 4タブナビゲーション（本日の予定/カレンダー/ルーティン/マイページ）に変更

## 変更ファイル
- `frontend/app/(tabs)/_layout.tsx` - 4タブ構成に更新
- `frontend/app/(tabs)/index.tsx` - ホーム画面をフル実装
- `frontend/app/(tabs)/calendar.tsx` - カレンダー画面を実装
- `frontend/app/(tabs)/routine.tsx` - ルーティンタブ（プレースホルダー）
- `frontend/app/(tabs)/mypage.tsx` - マイページタブ（プレースホルダー）

## Test plan
- [ ] `pnpm dev` でExpo開発サーバーが起動すること
- [ ] iOSシミュレータでホーム画面が表示されること
- [ ] カレンダータブで月カレンダーが表示され、日付選択できること
- [ ] 4つのタブが正しく切り替わること
- [ ] スクロールが正常に動作すること
- [ ] FABボタンが適切な位置に表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)