### PR TITLE
feat: Figmaデザインに基づく予定登録画面群を実装

### DIFF
--- a/frontend/app/(tabs)/calendar.tsx
+++ b/frontend/app/(tabs)/calendar.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useRouter } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
 
 const C = {
@@ -52,6 +53,7 @@ function getCalendarDays(year: number, month: number) {
 
 export default function CalendarScreen() {
   const insets = useSafeAreaInsets();
+  const router = useRouter();
   const [selectedDay, setSelectedDay] = useState(3);
   const year = 2025;
   const month = 2; // March (0-indexed)
@@ -98,7 +100,10 @@ export default function CalendarScreen() {
                   key={`${wi}-${di}`}
                   style={styles.dayCell}
                   onPress={() => {
-                    if (item.currentMonth) setSelectedDay(item.day);
+                    if (item.currentMonth) {
+                      setSelectedDay(item.day);
+                      router.push('/schedule');
+                    }
                   }}
                   activeOpacity={item.currentMonth ? 0.6 : 1}
                 >

--- a/frontend/app/_layout.tsx
+++ b/frontend/app/_layout.tsx
@@ -16,6 +16,7 @@ export default function RootLayout() {
     <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
       <Stack>
         <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+        <Stack.Screen name="schedule" options={{ headerShown: false }} />
         <Stack.Screen name="modal" options={{ presentation: 'modal', title: 'Modal' }} />
       </Stack>
       <StatusBar style="auto" />

--- a/frontend/app/schedule/_layout.tsx
+++ b/frontend/app/schedule/_layout.tsx
@@ -1,0 +1,5 @@
+import { Stack } from 'expo-router';
+
+export default function ScheduleLayout() {
+  return <Stack screenOptions={{ headerShown: false }} />;
+}

--- a/frontend/app/schedule/index.tsx
+++ b/frontend/app/schedule/index.tsx
@@ -28,6 +28,10 @@ export default function ScheduleIndexScreen() {
     <View style={styles.container}>
       {/* Header */}
       <View style={[styles.header, { paddingTop: insets.top + 10 }]}>
+        <TouchableOpacity style={styles.backButton} onPress={() => router.back()}>
+          <Ionicons name="chevron-back" size={22} color={C.white} />
+          <Text style={styles.backText}>カレンダー</Text>
+        </TouchableOpacity>
         <View style={styles.chatRow}>
           <View style={styles.avatar}>
             <Ionicons name="person" size={22} color={C.white} />
@@ -113,7 +117,9 @@ export default function ScheduleIndexScreen() {
 
 const styles = StyleSheet.create({
   container: { flex: 1, backgroundColor: C.headerBg },
-  header: { backgroundColor: C.headerBg, paddingHorizontal: 14, paddingBottom: 24.5 },
+  header: { backgroundColor: C.headerBg, paddingHorizontal: 14, paddingBottom: 24.5, gap: 12 },
+  backButton: { flexDirection: 'row', alignItems: 'center', gap: 4 },
+  backText: { fontSize: 14, fontWeight: '500', color: C.white },
   chatRow: { flexDirection: 'row', alignItems: 'flex-start', gap: 10 },
   avatar: {
     width: 42,

--- a/frontend/app/schedule/index.tsx
+++ b/frontend/app/schedule/index.tsx
@@ -1,0 +1,242 @@
+import React from 'react';
+import { ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useRouter } from 'expo-router';
+import { Ionicons, MaterialCommunityIcons } from '@expo/vector-icons';
+
+const C = {
+  headerBg: '#436F9B',
+  primary: '#436F9B',
+  accent: '#6E8F8A',
+  todoBg: '#E6EDF6',
+  todoBorder: '#A8C0DD',
+  weatherBg: '#EDF0F2',
+  trainBg: '#EEF0F1',
+  textPrimary: '#1F2528',
+  textSecondary: '#63747E',
+  textMuted: '#B5BFC5',
+  black: '#000000',
+  white: '#FFFFFF',
+  warmText: '#AA8A5E',
+};
+
+export default function ScheduleIndexScreen() {
+  const insets = useSafeAreaInsets();
+  const router = useRouter();
+
+  return (
+    <View style={styles.container}>
+      {/* Header */}
+      <View style={[styles.header, { paddingTop: insets.top + 10 }]}>
+        <View style={styles.chatRow}>
+          <View style={styles.avatar}>
+            <Ionicons name="person" size={22} color={C.white} />
+          </View>
+          <View style={styles.chatBubble}>
+            <Text style={styles.chatText}>スケジュールを登録しよう！</Text>
+          </View>
+        </View>
+      </View>
+
+      <ScrollView
+        style={styles.scrollView}
+        contentContainerStyle={styles.scrollContent}
+        showsVerticalScrollIndicator={false}
+      >
+        <View style={styles.mainContent}>
+          {/* Checklist */}
+          <View style={styles.todoCard}>
+            <View style={styles.todoHeader}>
+              <MaterialCommunityIcons
+                name="clipboard-text-outline"
+                size={24.5}
+                color={C.textPrimary}
+              />
+              <Text style={styles.todoHeaderText}>前日までに準備すること！</Text>
+            </View>
+            <View style={styles.todoBody}>
+              <View style={styles.todoRow}>
+                <Ionicons name="checkbox" size={22} color="#4CAF50" />
+                <Text style={styles.todoCheckedText}>折りたたみ傘</Text>
+              </View>
+              <View style={styles.dashedDivider} />
+              <View style={styles.todoRow}>
+                <View style={styles.uncheckedBox} />
+                <Text style={styles.todoText}>スーツ</Text>
+              </View>
+            </View>
+          </View>
+
+          {/* Weather + Train */}
+          <View style={styles.infoRow}>
+            <View style={styles.weatherCard}>
+              <Ionicons name="cloud" size={23} color={C.textSecondary} />
+              <Text style={styles.weatherTemp}>18℃ / 12℃</Text>
+              <Text style={styles.weatherNote}>午後から雨</Text>
+            </View>
+            <View style={styles.trainCard}>
+              <MaterialCommunityIcons name="train" size={28} color={C.textPrimary} />
+              <Text style={styles.trainTime}>08:34発</Text>
+            </View>
+          </View>
+
+          {/* Schedule title */}
+          <Text style={styles.scheduleTitle}>3/6 (金)の予定</Text>
+
+          {/* Routine card */}
+          <View style={styles.routineCard}>
+            <View style={styles.routineInner}>
+              <Ionicons name="briefcase-outline" size={20} color={C.accent} />
+              <View style={styles.routineTextWrap}>
+                <Text style={styles.routineTitle}>友達と一日遊ぶ日</Text>
+                <Text style={styles.routineMemo}>お店の予約をする！</Text>
+              </View>
+            </View>
+          </View>
+
+          {/* CTA */}
+          <View style={styles.ctaSection}>
+            <Text style={styles.ctaText}>スケジュールを登録しよう！</Text>
+            <TouchableOpacity
+              style={styles.registerButton}
+              onPress={() => router.push('/schedule/register')}
+            >
+              <Ionicons name="add" size={18} color={C.white} />
+              <Text style={styles.registerButtonText}>登録</Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+      </ScrollView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: C.headerBg },
+  header: { backgroundColor: C.headerBg, paddingHorizontal: 14, paddingBottom: 24.5 },
+  chatRow: { flexDirection: 'row', alignItems: 'flex-start', gap: 10 },
+  avatar: {
+    width: 42,
+    height: 42,
+    borderRadius: 21,
+    backgroundColor: 'rgba(255,255,255,0.3)',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  chatBubble: {
+    flex: 1,
+    backgroundColor: C.white,
+    borderTopLeftRadius: 3.5,
+    borderTopRightRadius: 10.5,
+    borderBottomLeftRadius: 10.5,
+    borderBottomRightRadius: 10.5,
+    padding: 12,
+  },
+  chatText: { fontSize: 14, fontWeight: '400', lineHeight: 21, color: C.textPrimary },
+  scrollView: { flex: 1 },
+  scrollContent: { paddingBottom: 100 },
+  mainContent: {
+    backgroundColor: C.white,
+    borderTopLeftRadius: 10.5,
+    borderTopRightRadius: 10.5,
+    marginTop: -8,
+    paddingHorizontal: 14,
+    paddingTop: 17.5,
+    paddingBottom: 17.5,
+    gap: 17.5,
+    minHeight: 600,
+  },
+
+  // Todo
+  todoCard: { borderWidth: 2, borderColor: C.todoBorder, borderRadius: 14, overflow: 'hidden' },
+  todoHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    backgroundColor: C.todoBg,
+    borderBottomWidth: 2,
+    borderBottomColor: C.todoBorder,
+    paddingHorizontal: 17.5,
+    paddingVertical: 12.25,
+  },
+  todoHeaderText: { fontSize: 14, fontWeight: '700', color: C.textPrimary },
+  todoBody: { paddingHorizontal: 17.5, paddingVertical: 17.5, gap: 17.5 },
+  todoRow: { flexDirection: 'row', alignItems: 'center', gap: 10 },
+  todoCheckedText: {
+    fontSize: 14,
+    fontWeight: '500',
+    color: C.textPrimary,
+    textDecorationLine: 'line-through',
+    textDecorationColor: C.textMuted,
+  },
+  todoText: { fontSize: 14, fontWeight: '500', color: C.textPrimary },
+  uncheckedBox: {
+    width: 22,
+    height: 22,
+    borderRadius: 4,
+    borderWidth: 1,
+    borderColor: C.textMuted,
+  },
+  dashedDivider: {
+    height: 0,
+    borderBottomWidth: 1.5,
+    borderBottomColor: C.todoBorder,
+    borderStyle: 'dashed',
+  },
+
+  // Info row
+  infoRow: { flexDirection: 'row', gap: 17.5 },
+  weatherCard: {
+    flex: 1,
+    backgroundColor: C.weatherBg,
+    borderRadius: 7,
+    paddingVertical: 7,
+    paddingHorizontal: 12.25,
+    alignItems: 'center',
+    gap: 7,
+  },
+  weatherTemp: { fontSize: 12.25, fontWeight: '500', color: C.textPrimary },
+  weatherNote: { fontSize: 12.25, fontWeight: '500', color: C.warmText },
+  trainCard: {
+    flex: 1,
+    backgroundColor: C.trainBg,
+    borderRadius: 7,
+    paddingVertical: 7,
+    paddingHorizontal: 12.25,
+    alignItems: 'center',
+    gap: 7,
+  },
+  trainTime: { fontSize: 15.75, fontWeight: '500', color: C.textPrimary },
+
+  // Schedule
+  scheduleTitle: { fontSize: 17.5, fontWeight: '700', color: C.black },
+
+  // Routine
+  routineCard: {
+    borderWidth: 1,
+    borderColor: C.accent,
+    borderRadius: 7,
+    borderLeftWidth: 6,
+    borderLeftColor: C.accent,
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+  },
+  routineInner: { flexDirection: 'row', alignItems: 'center', gap: 10 },
+  routineTextWrap: { flex: 1, gap: 4 },
+  routineTitle: { fontSize: 14, fontWeight: '700', color: C.textPrimary },
+  routineMemo: { fontSize: 12.25, fontWeight: '400', color: C.textSecondary },
+
+  // CTA
+  ctaSection: { alignItems: 'center', gap: 14, paddingVertical: 20 },
+  ctaText: { fontSize: 14, fontWeight: '500', color: C.textSecondary },
+  registerButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+    backgroundColor: C.primary,
+    borderRadius: 7,
+    paddingHorizontal: 20,
+    paddingVertical: 10,
+  },
+  registerButtonText: { fontSize: 14, fontWeight: '700', color: C.white },
+});

--- a/frontend/app/schedule/register.tsx
+++ b/frontend/app/schedule/register.tsx
@@ -1,0 +1,382 @@
+import React, { useState } from 'react';
+import {
+  Modal,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useRouter } from 'expo-router';
+import { Ionicons, MaterialCommunityIcons, FontAwesome5 } from '@expo/vector-icons';
+
+const C = {
+  primary: '#436F9B',
+  accent: '#6E8F8A',
+  bg: '#EEF0F1',
+  white: '#FFFFFF',
+  textPrimary: '#1F2528',
+  textSecondary: '#63747E',
+  textMuted: '#B5BFC5',
+  black: '#000000',
+  border: '#EEF0F1',
+  placeholder: '#98A6AE',
+};
+
+type ScheduleType = '休日' | '旅行' | '仕事' | '出張';
+
+const SCHEDULE_TYPES: { label: ScheduleType; icon: string; iconSet: 'ionicons' | 'fa5' | 'mci' }[] =
+  [
+    { label: '休日', icon: 'bicycle', iconSet: 'ionicons' },
+    { label: '旅行', icon: 'suitcase-rolling', iconSet: 'fa5' },
+    { label: '仕事', icon: 'briefcase-outline', iconSet: 'mci' },
+    { label: '出張', icon: 'briefcase', iconSet: 'fa5' },
+  ];
+
+export default function RegisterScreen() {
+  const insets = useSafeAreaInsets();
+  const router = useRouter();
+
+  const [step, setStep] = useState<'method' | 'form'>('method');
+  const [title, setTitle] = useState('');
+  const [memo, setMemo] = useState('');
+  const [selectedType, setSelectedType] = useState<ScheduleType>('休日');
+  const [belongings, setBelongings] = useState<string[]>(['財布', '充電器']);
+  const [newBelonging, setNewBelonging] = useState('');
+  const [showModal, setShowModal] = useState(false);
+
+  function handleSave() {
+    setShowModal(true);
+  }
+
+  function removeBelonging(index: number) {
+    setBelongings(prev => prev.filter((_, i) => i !== index));
+  }
+
+  function addBelonging() {
+    if (newBelonging.trim()) {
+      setBelongings(prev => [...prev, newBelonging.trim()]);
+      setNewBelonging('');
+    }
+  }
+
+  function renderTypeIcon(item: (typeof SCHEDULE_TYPES)[number], color: string) {
+    const size = 20;
+    if (item.iconSet === 'ionicons')
+      return <Ionicons name={item.icon as any} size={size} color={color} />;
+    if (item.iconSet === 'fa5') return <FontAwesome5 name={item.icon} size={size} color={color} />;
+    return <MaterialCommunityIcons name={item.icon as any} size={size} color={color} />;
+  }
+
+  return (
+    <View style={[styles.container, { paddingTop: insets.top }]}>
+      {/* Header */}
+      <View style={styles.header}>
+        <TouchableOpacity
+          onPress={() => {
+            if (step === 'form') setStep('method');
+            else router.back();
+          }}
+        >
+          <Ionicons name="chevron-back" size={24} color={C.textPrimary} />
+        </TouchableOpacity>
+        <Text style={styles.headerTitle}>予定を登録</Text>
+        <TouchableOpacity onPress={step === 'form' ? handleSave : undefined}>
+          <Text style={[styles.saveText, step !== 'form' && { opacity: 0.3 }]}>保存</Text>
+        </TouchableOpacity>
+      </View>
+
+      <ScrollView
+        style={styles.scrollView}
+        contentContainerStyle={styles.scrollContent}
+        showsVerticalScrollIndicator={false}
+      >
+        {/* Registration method */}
+        <View style={styles.section}>
+          <View style={styles.sectionHeader}>
+            <Text style={styles.sectionLabel}>登録方法</Text>
+            <Ionicons name="help-circle-outline" size={17.5} color={C.textSecondary} />
+          </View>
+          <View style={styles.methodRow}>
+            <TouchableOpacity
+              style={[styles.methodCard, step === 'form' && styles.methodCardSelected]}
+              onPress={() => setStep('form')}
+            >
+              <Ionicons name="calendar-outline" size={28} color={C.textPrimary} />
+              <Text style={styles.methodText}>新しく登録</Text>
+            </TouchableOpacity>
+            <TouchableOpacity style={styles.methodCard}>
+              <MaterialCommunityIcons name="arrow-u-left-top" size={28} color={C.textPrimary} />
+              <Text style={styles.methodText}>ルーティンで登録</Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+
+        {/* Form (only visible after selecting method) */}
+        {step === 'form' && (
+          <>
+            {/* Title */}
+            <View style={styles.formCard}>
+              <Text style={styles.formLabel}>予定のタイトル</Text>
+              <TextInput
+                style={styles.formInput}
+                placeholder="友達と一日遊ぶ日"
+                placeholderTextColor={C.placeholder}
+                value={title}
+                onChangeText={setTitle}
+              />
+            </View>
+
+            {/* Memo */}
+            <View style={styles.formCard}>
+              <Text style={styles.formLabel}>一言メモ</Text>
+              <TextInput
+                style={styles.formInput}
+                placeholder="お店の予約をする！"
+                placeholderTextColor={C.placeholder}
+                value={memo}
+                onChangeText={setMemo}
+              />
+            </View>
+
+            {/* Schedule type */}
+            <View style={styles.section}>
+              <Text style={styles.sectionLabel}>予定の種類</Text>
+              <View style={styles.typeRow}>
+                {SCHEDULE_TYPES.map(t => {
+                  const isSelected = selectedType === t.label;
+                  return (
+                    <TouchableOpacity
+                      key={t.label}
+                      style={[styles.typeButton, isSelected && styles.typeButtonSelected]}
+                      onPress={() => setSelectedType(t.label)}
+                    >
+                      {renderTypeIcon(t, isSelected ? C.white : C.textSecondary)}
+                      <Text style={[styles.typeText, isSelected && styles.typeTextSelected]}>
+                        {t.label}
+                      </Text>
+                    </TouchableOpacity>
+                  );
+                })}
+              </View>
+            </View>
+
+            {/* Belongings */}
+            <View style={styles.section}>
+              <Text style={styles.sectionLabel}>持ち物</Text>
+              <View style={styles.belongingsCard}>
+                {belongings.map((item, i) => (
+                  <View key={`${item}-${i}`}>
+                    <View style={styles.belongingRow}>
+                      <Text style={styles.belongingText}>{item}</Text>
+                      <TouchableOpacity onPress={() => removeBelonging(i)}>
+                        <Ionicons name="remove-circle" size={22} color="#E57373" />
+                      </TouchableOpacity>
+                    </View>
+                    {i < belongings.length - 1 && <View style={styles.belongingDivider} />}
+                  </View>
+                ))}
+              </View>
+              <View style={styles.addBelongingRow}>
+                <TextInput
+                  style={styles.addBelongingInput}
+                  placeholder="持ち物を入力"
+                  placeholderTextColor={C.placeholder}
+                  value={newBelonging}
+                  onChangeText={setNewBelonging}
+                  onSubmitEditing={addBelonging}
+                />
+                <TouchableOpacity style={styles.addBelongingButton} onPress={addBelonging}>
+                  <Ionicons name="add" size={16} color={C.primary} />
+                  <Text style={styles.addBelongingButtonText}>持ち物を追加</Text>
+                </TouchableOpacity>
+              </View>
+            </View>
+
+            {/* Departure */}
+            <View style={styles.section}>
+              <Text style={styles.sectionLabel}>出発地</Text>
+              <TouchableOpacity style={styles.departureCard}>
+                <Ionicons name="location-outline" size={20} color={C.textSecondary} />
+                <Text style={styles.departureText}>自宅</Text>
+                <Ionicons name="chevron-forward" size={18} color={C.textMuted} />
+              </TouchableOpacity>
+            </View>
+          </>
+        )}
+      </ScrollView>
+
+      {/* Success Modal */}
+      <Modal visible={showModal} transparent animationType="fade">
+        <View style={styles.modalOverlay}>
+          <View style={styles.modalContent}>
+            <Ionicons name="checkmark-circle" size={48} color={C.accent} />
+            <Text style={styles.modalTitle}>予定を登録しました！</Text>
+            <Text style={styles.modalDesc}>続けてスケジュールも作成しますか？</Text>
+            <View style={styles.modalButtons}>
+              <TouchableOpacity
+                style={styles.modalButtonSecondary}
+                onPress={() => {
+                  setShowModal(false);
+                  router.back();
+                }}
+              >
+                <Text style={styles.modalButtonSecondaryText}>閉じる</Text>
+              </TouchableOpacity>
+              <TouchableOpacity
+                style={styles.modalButtonPrimary}
+                onPress={() => {
+                  setShowModal(false);
+                  // TODO: navigate to schedule creation
+                }}
+              >
+                <Text style={styles.modalButtonPrimaryText}>スケジュール作成</Text>
+              </TouchableOpacity>
+            </View>
+          </View>
+        </View>
+      </Modal>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: C.bg },
+
+  // Header
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 14,
+    height: 56,
+    backgroundColor: C.white,
+    borderBottomWidth: 1,
+    borderBottomColor: C.border,
+  },
+  headerTitle: { fontSize: 15.75, fontWeight: '700', color: C.textPrimary },
+  saveText: { fontSize: 14, fontWeight: '700', color: C.primary },
+
+  // Scroll
+  scrollView: { flex: 1 },
+  scrollContent: { padding: 14, paddingTop: 17.5, paddingBottom: 100, gap: 17.5 },
+
+  // Section
+  section: { gap: 10 },
+  sectionHeader: { flexDirection: 'row', alignItems: 'center', gap: 7 },
+  sectionLabel: { fontSize: 14, fontWeight: '500', color: C.textSecondary },
+
+  // Method cards
+  methodRow: { flexDirection: 'row', gap: 17.5 },
+  methodCard: {
+    flex: 1,
+    backgroundColor: C.white,
+    borderRadius: 7,
+    paddingVertical: 12.25,
+    alignItems: 'center',
+    gap: 7,
+  },
+  methodCardSelected: { borderWidth: 2, borderColor: C.primary },
+  methodText: { fontSize: 14, fontWeight: '500', color: C.textPrimary },
+
+  // Form card
+  formCard: {
+    backgroundColor: C.white,
+    borderRadius: 7,
+    padding: 14,
+    gap: 8,
+  },
+  formLabel: { fontSize: 14, fontWeight: '500', color: C.textSecondary },
+  formInput: { fontSize: 16, fontWeight: '500', color: C.textPrimary, paddingVertical: 4 },
+
+  // Type selector
+  typeRow: { flexDirection: 'row', gap: 10 },
+  typeButton: {
+    flex: 1,
+    backgroundColor: C.white,
+    borderRadius: 7,
+    paddingVertical: 10,
+    alignItems: 'center',
+    gap: 4,
+  },
+  typeButtonSelected: { backgroundColor: C.accent },
+  typeText: { fontSize: 12.25, fontWeight: '500', color: C.textSecondary },
+  typeTextSelected: { color: C.white },
+
+  // Belongings
+  belongingsCard: { backgroundColor: C.white, borderRadius: 7, padding: 14 },
+  belongingRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingVertical: 8,
+  },
+  belongingText: { fontSize: 14, fontWeight: '500', color: C.textPrimary },
+  belongingDivider: { height: 1, backgroundColor: C.border },
+  addBelongingRow: { flexDirection: 'row', gap: 10, alignItems: 'center' },
+  addBelongingInput: {
+    flex: 1,
+    backgroundColor: C.white,
+    borderRadius: 7,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    fontSize: 14,
+    color: C.textPrimary,
+  },
+  addBelongingButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+  },
+  addBelongingButtonText: { fontSize: 12.25, fontWeight: '500', color: C.primary },
+
+  // Departure
+  departureCard: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: C.white,
+    borderRadius: 7,
+    padding: 14,
+    gap: 10,
+  },
+  departureText: { flex: 1, fontSize: 14, fontWeight: '500', color: C.textPrimary },
+
+  // Modal
+  modalOverlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.4)',
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: 30,
+  },
+  modalContent: {
+    backgroundColor: C.white,
+    borderRadius: 14,
+    padding: 24,
+    alignItems: 'center',
+    gap: 12,
+    width: '100%',
+  },
+  modalTitle: { fontSize: 17.5, fontWeight: '700', color: C.textPrimary },
+  modalDesc: { fontSize: 14, fontWeight: '400', color: C.textSecondary, textAlign: 'center' },
+  modalButtons: { flexDirection: 'row', gap: 12, marginTop: 8, width: '100%' },
+  modalButtonSecondary: {
+    flex: 1,
+    borderWidth: 1,
+    borderColor: C.border,
+    borderRadius: 7,
+    paddingVertical: 12,
+    alignItems: 'center',
+  },
+  modalButtonSecondaryText: { fontSize: 14, fontWeight: '700', color: C.textSecondary },
+  modalButtonPrimary: {
+    flex: 1,
+    backgroundColor: C.primary,
+    borderRadius: 7,
+    paddingVertical: 12,
+    alignItems: 'center',
+  },
+  modalButtonPrimaryText: { fontSize: 14, fontWeight: '700', color: C.white },
+});

--- a/frontend/app/schedule/register.tsx
+++ b/frontend/app/schedule/register.tsx
@@ -70,13 +70,16 @@ function RoutinePickerModal({
   selectedId,
   onSelect,
   onClose,
+  bottomInset,
 }: {
   visible: boolean;
   routines: Routine[];
   selectedId: string;
   onSelect: (r: Routine) => void;
   onClose: () => void;
+  bottomInset: number;
 }) {
+  const safeBottom = Math.max(bottomInset, 20);
   const slideAnim = useRef(new Animated.Value(600)).current;
 
   useEffect(() => {
@@ -184,7 +187,10 @@ function RoutinePickerModal({
             </View>
 
             {/* Close */}
-            <TouchableOpacity style={pickerStyles.closeButton} onPress={handleClose}>
+            <TouchableOpacity
+              style={[pickerStyles.closeButton, { paddingBottom: 20 + safeBottom }]}
+              onPress={handleClose}
+            >
               <Text style={pickerStyles.closeText}>キャンセル</Text>
             </TouchableOpacity>
           </Animated.View>
@@ -201,20 +207,19 @@ const pickerStyles = StyleSheet.create({
     justifyContent: 'flex-end',
   },
   cardWrap: {
+    maxHeight: '80%',
     width: '100%',
   },
   card: {
     backgroundColor: C.white,
     borderTopLeftRadius: 20,
     borderTopRightRadius: 20,
-    width: '100%',
-    overflow: 'hidden',
     shadowColor: '#0F171E',
     shadowOffset: { width: 0, height: -4 },
     shadowOpacity: 0.12,
     shadowRadius: 16,
     elevation: 12,
-    maxHeight: '85%',
+    paddingBottom: 40,
   },
   header: {
     paddingHorizontal: 20,
@@ -242,6 +247,7 @@ const pickerStyles = StyleSheet.create({
   },
   list: {
     paddingHorizontal: 12,
+    paddingBottom: 4,
     gap: 6,
   },
   routineItem: {
@@ -295,7 +301,8 @@ const pickerStyles = StyleSheet.create({
   },
   closeButton: {
     alignItems: 'center',
-    paddingVertical: 16,
+    paddingTop: 16,
+    paddingBottom: 34,
     marginTop: 8,
     borderTopWidth: StyleSheet.hairlineWidth,
     borderTopColor: '#E8EAEC',
@@ -581,6 +588,7 @@ export default function RegisterScreen() {
           setSelectedRoutine(routine);
         }}
         onClose={() => setShowRoutinePicker(false)}
+        bottomInset={insets.bottom}
       />
 
       {/* Success Modal */}

--- a/frontend/app/schedule/register.tsx
+++ b/frontend/app/schedule/register.tsx
@@ -1,6 +1,8 @@
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import {
+  Animated,
   Modal,
+  Pressable,
   ScrollView,
   StyleSheet,
   Text,
@@ -61,6 +63,249 @@ const ROUTINES: Routine[] = [
   },
   { id: '3', title: '休日①', accentColor: C.holidayAccent, steps: ['荻窪発', '渋谷着', 'MTG'] },
 ];
+
+function RoutinePickerModal({
+  visible,
+  routines,
+  selectedId,
+  onSelect,
+  onClose,
+}: {
+  visible: boolean;
+  routines: Routine[];
+  selectedId: string;
+  onSelect: (r: Routine) => void;
+  onClose: () => void;
+}) {
+  const slideAnim = useRef(new Animated.Value(600)).current;
+
+  useEffect(() => {
+    if (visible) {
+      slideAnim.setValue(600);
+      Animated.spring(slideAnim, {
+        toValue: 0,
+        tension: 50,
+        friction: 10,
+        useNativeDriver: true,
+      }).start();
+    }
+  }, [visible]);
+
+  function handleClose() {
+    Animated.timing(slideAnim, {
+      toValue: 600,
+      duration: 200,
+      useNativeDriver: true,
+    }).start(() => onClose());
+  }
+
+  if (!visible) return null;
+
+  return (
+    <Modal visible transparent statusBarTranslucent>
+      <Pressable style={pickerStyles.backdrop} onPress={handleClose}>
+        <Pressable onPress={e => e.stopPropagation()} style={pickerStyles.cardWrap}>
+          <Animated.View style={[pickerStyles.card, { transform: [{ translateY: slideAnim }] }]}>
+            {/* Header */}
+            <View style={pickerStyles.header}>
+              <View style={pickerStyles.headerAccent} />
+              <Text style={pickerStyles.title}>ルーティンを選択</Text>
+              <Text style={pickerStyles.subtitle}>予定に適用するルーティンを選んでください</Text>
+            </View>
+
+            {/* Routine list */}
+            <View style={pickerStyles.list}>
+              {routines.map(routine => {
+                const isSelected = selectedId === routine.id;
+                return (
+                  <TouchableOpacity
+                    key={routine.id}
+                    style={[pickerStyles.routineItem, isSelected && pickerStyles.routineItemActive]}
+                    onPress={() => {
+                      onSelect(routine);
+                      handleClose();
+                    }}
+                    activeOpacity={0.65}
+                  >
+                    <View
+                      style={[
+                        pickerStyles.routineAccentBar,
+                        { backgroundColor: routine.accentColor },
+                      ]}
+                    />
+                    <View style={pickerStyles.routineBody}>
+                      <View style={pickerStyles.routineTitleRow}>
+                        <Text
+                          style={[pickerStyles.routineTitle, isSelected && { color: C.primary }]}
+                        >
+                          {routine.title}
+                        </Text>
+                        {isSelected && (
+                          <Ionicons name="checkmark-circle" size={20} color={C.primary} />
+                        )}
+                      </View>
+                      <View style={pickerStyles.stepsRow}>
+                        {routine.steps.map((s, i) => (
+                          <React.Fragment key={`${routine.id}-step-${i}`}>
+                            <View
+                              style={[
+                                pickerStyles.stepChip,
+                                {
+                                  backgroundColor: isSelected
+                                    ? `${routine.accentColor}18`
+                                    : '#F5F6F7',
+                                },
+                              ]}
+                            >
+                              <Text
+                                style={[
+                                  pickerStyles.stepChipText,
+                                  isSelected && { color: routine.accentColor },
+                                ]}
+                              >
+                                {s}
+                              </Text>
+                            </View>
+                            {i < routine.steps.length - 1 && (
+                              <Ionicons
+                                name="arrow-forward"
+                                size={11}
+                                color={C.textMuted}
+                                style={{ marginHorizontal: 2 }}
+                              />
+                            )}
+                          </React.Fragment>
+                        ))}
+                      </View>
+                    </View>
+                  </TouchableOpacity>
+                );
+              })}
+            </View>
+
+            {/* Close */}
+            <TouchableOpacity style={pickerStyles.closeButton} onPress={handleClose}>
+              <Text style={pickerStyles.closeText}>キャンセル</Text>
+            </TouchableOpacity>
+          </Animated.View>
+        </Pressable>
+      </Pressable>
+    </Modal>
+  );
+}
+
+const pickerStyles = StyleSheet.create({
+  backdrop: {
+    flex: 1,
+    backgroundColor: 'rgba(15, 23, 30, 0.55)',
+    justifyContent: 'flex-end',
+  },
+  cardWrap: {
+    width: '100%',
+  },
+  card: {
+    backgroundColor: C.white,
+    borderTopLeftRadius: 20,
+    borderTopRightRadius: 20,
+    width: '100%',
+    overflow: 'hidden',
+    shadowColor: '#0F171E',
+    shadowOffset: { width: 0, height: -4 },
+    shadowOpacity: 0.12,
+    shadowRadius: 16,
+    elevation: 12,
+    maxHeight: '85%',
+  },
+  header: {
+    paddingHorizontal: 20,
+    paddingTop: 22,
+    paddingBottom: 16,
+  },
+  headerAccent: {
+    width: 32,
+    height: 3,
+    backgroundColor: C.primary,
+    borderRadius: 2,
+    marginBottom: 14,
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: '700',
+    color: C.textPrimary,
+    letterSpacing: -0.3,
+  },
+  subtitle: {
+    fontSize: 13,
+    fontWeight: '400',
+    color: C.textSecondary,
+    marginTop: 4,
+  },
+  list: {
+    paddingHorizontal: 12,
+    gap: 6,
+  },
+  routineItem: {
+    flexDirection: 'row',
+    alignItems: 'stretch',
+    borderRadius: 10,
+    backgroundColor: '#F8F9FA',
+    overflow: 'hidden',
+  },
+  routineItemActive: {
+    backgroundColor: '#EDF2F8',
+    borderWidth: 1.5,
+    borderColor: `${C.primary}40`,
+  },
+  routineAccentBar: {
+    width: 4,
+    borderRadius: 2,
+    marginVertical: 8,
+    marginLeft: 4,
+  },
+  routineBody: {
+    flex: 1,
+    paddingVertical: 12,
+    paddingHorizontal: 14,
+    gap: 8,
+  },
+  routineTitleRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  routineTitle: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: C.textPrimary,
+  },
+  stepsRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    flexWrap: 'wrap',
+  },
+  stepChip: {
+    paddingHorizontal: 8,
+    paddingVertical: 3,
+    borderRadius: 5,
+  },
+  stepChipText: {
+    fontSize: 11.5,
+    fontWeight: '500',
+    color: C.textSecondary,
+  },
+  closeButton: {
+    alignItems: 'center',
+    paddingVertical: 16,
+    marginTop: 8,
+    borderTopWidth: StyleSheet.hairlineWidth,
+    borderTopColor: '#E8EAEC',
+  },
+  closeText: {
+    fontSize: 14,
+    fontWeight: '500',
+    color: C.textSecondary,
+  },
+});
 
 export default function RegisterScreen() {
   const insets = useSafeAreaInsets();
@@ -328,56 +573,15 @@ export default function RegisterScreen() {
       </ScrollView>
 
       {/* Routine Picker Modal */}
-      <Modal visible={showRoutinePicker} transparent animationType="slide">
-        <View style={styles.pickerOverlay}>
-          <View style={styles.pickerContent}>
-            <View style={styles.pickerHeader}>
-              <Text style={styles.pickerTitle}>ルーティンを選択</Text>
-              <TouchableOpacity onPress={() => setShowRoutinePicker(false)}>
-                <Ionicons name="close" size={24} color={C.textPrimary} />
-              </TouchableOpacity>
-            </View>
-            <ScrollView style={styles.pickerScroll}>
-              {ROUTINES.map(routine => (
-                <TouchableOpacity
-                  key={routine.id}
-                  style={[
-                    styles.pickerRoutineCard,
-                    selectedRoutine.id === routine.id && styles.pickerRoutineCardSelected,
-                  ]}
-                  onPress={() => {
-                    setSelectedRoutine(routine);
-                    setShowRoutinePicker(false);
-                  }}
-                >
-                  <View
-                    style={[styles.pickerRoutineInner, { borderLeftColor: routine.accentColor }]}
-                  >
-                    <Text style={styles.pickerRoutineTitle}>{routine.title}</Text>
-                    <View style={styles.stepsRow}>
-                      {routine.steps.map((s, i) => (
-                        <View key={`pick-${routine.id}-${i}`} style={styles.stepItem}>
-                          <View style={styles.stepDotRow}>
-                            <View
-                              style={[styles.stepDot, { backgroundColor: routine.accentColor }]}
-                            />
-                            {i < routine.steps.length - 1 && (
-                              <View
-                                style={[styles.stepLine, { backgroundColor: C.stepConnector }]}
-                              />
-                            )}
-                          </View>
-                          <Text style={styles.stepText}>{s}</Text>
-                        </View>
-                      ))}
-                    </View>
-                  </View>
-                </TouchableOpacity>
-              ))}
-            </ScrollView>
-          </View>
-        </View>
-      </Modal>
+      <RoutinePickerModal
+        visible={showRoutinePicker}
+        routines={ROUTINES}
+        selectedId={selectedRoutine.id}
+        onSelect={routine => {
+          setSelectedRoutine(routine);
+        }}
+        onClose={() => setShowRoutinePicker(false)}
+      />
 
       {/* Success Modal */}
       <Modal visible={showModal} transparent animationType="fade">
@@ -522,49 +726,7 @@ const styles = StyleSheet.create({
   selectedRoutineTitle: { fontSize: 14, fontWeight: '700', color: C.textPrimary },
   addBelongingRowEnd: { alignItems: 'flex-end' },
 
-  // Routine picker modal
-  pickerOverlay: {
-    flex: 1,
-    backgroundColor: 'rgba(0,0,0,0.4)',
-    justifyContent: 'flex-end',
-  },
-  pickerContent: {
-    backgroundColor: C.white,
-    borderTopLeftRadius: 14,
-    borderTopRightRadius: 14,
-    maxHeight: '70%',
-    padding: 20,
-  },
-  pickerHeader: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    marginBottom: 16,
-  },
-  pickerTitle: { fontSize: 17.5, fontWeight: '700', color: C.textPrimary },
-  pickerScroll: { gap: 12 },
-  pickerRoutineCard: {
-    borderWidth: 1,
-    borderColor: C.border,
-    borderRadius: 7,
-    overflow: 'hidden',
-    marginBottom: 12,
-  },
-  pickerRoutineCardSelected: { borderColor: C.primary, borderWidth: 2 },
-  pickerRoutineInner: {
-    borderLeftWidth: 6,
-    borderRadius: 7,
-    paddingVertical: 12.25,
-    paddingHorizontal: 17.5,
-    gap: 12.25,
-  },
-  pickerRoutineTitle: { fontSize: 14, fontWeight: '700', color: C.textPrimary },
-  stepsRow: { flexDirection: 'row', gap: 8 },
-  stepItem: { alignItems: 'center', gap: 7 },
-  stepDotRow: { flexDirection: 'row', alignItems: 'center' },
-  stepDot: { width: 12.25, height: 12.25, borderRadius: 6.125 },
-  stepLine: { width: 68, height: 2 },
-  stepText: { fontSize: 14, fontWeight: '500', color: C.textSecondary },
+  // (routine picker styles are in pickerStyles above)
 
   // Modal
   modalOverlay: {

--- a/frontend/app/schedule/register.tsx
+++ b/frontend/app/schedule/register.tsx
@@ -15,6 +15,7 @@ import { Ionicons, MaterialCommunityIcons, FontAwesome5 } from '@expo/vector-ico
 const C = {
   primary: '#436F9B',
   accent: '#6E8F8A',
+  holidayAccent: '#A86A78',
   bg: '#EEF0F1',
   white: '#FFFFFF',
   textPrimary: '#1F2528',
@@ -23,9 +24,19 @@ const C = {
   black: '#000000',
   border: '#EEF0F1',
   placeholder: '#98A6AE',
+  searchBg: '#EEF0F1',
+  stepConnector: '#C2A070',
 };
 
 type ScheduleType = '休日' | '旅行' | '仕事' | '出張';
+type Step = 'method' | 'form' | 'routine';
+
+type Routine = {
+  id: string;
+  title: string;
+  accentColor: string;
+  steps: string[];
+};
 
 const SCHEDULE_TYPES: { label: ScheduleType; icon: string; iconSet: 'ionicons' | 'fa5' | 'mci' }[] =
   [
@@ -35,19 +46,43 @@ const SCHEDULE_TYPES: { label: ScheduleType; icon: string; iconSet: 'ionicons' |
     { label: '出張', icon: 'briefcase', iconSet: 'fa5' },
   ];
 
+const ROUTINES: Routine[] = [
+  {
+    id: '1',
+    title: '仕事ルーティン①',
+    accentColor: C.accent,
+    steps: ['荻窪発', '渋谷着', 'MTG'],
+  },
+  {
+    id: '2',
+    title: '仕事ルーティン②',
+    accentColor: C.accent,
+    steps: ['荻窪発', '渋谷着', 'MTG'],
+  },
+  { id: '3', title: '休日①', accentColor: C.holidayAccent, steps: ['荻窪発', '渋谷着', 'MTG'] },
+];
+
 export default function RegisterScreen() {
   const insets = useSafeAreaInsets();
   const router = useRouter();
 
-  const [step, setStep] = useState<'method' | 'form'>('method');
+  const [step, setStep] = useState<Step>('method');
   const [title, setTitle] = useState('');
   const [memo, setMemo] = useState('');
   const [selectedType, setSelectedType] = useState<ScheduleType>('休日');
   const [belongings, setBelongings] = useState<string[]>(['財布', '充電器']);
   const [newBelonging, setNewBelonging] = useState('');
   const [showModal, setShowModal] = useState(false);
+  const [selectedRoutine, setSelectedRoutine] = useState<Routine | null>(null);
+  const [routineSearch, setRoutineSearch] = useState('');
 
   function handleSave() {
+    setShowModal(true);
+  }
+
+  function handleRoutineSelect(routine: Routine) {
+    setSelectedRoutine(routine);
+    setTitle(routine.title);
     setShowModal(true);
   }
 
@@ -62,6 +97,17 @@ export default function RegisterScreen() {
     }
   }
 
+  function handleBack() {
+    if (step === 'form' || step === 'routine') {
+      setStep('method');
+      setSelectedRoutine(null);
+    } else {
+      router.back();
+    }
+  }
+
+  const canSave = step === 'form' || (step === 'routine' && selectedRoutine);
+
   function renderTypeIcon(item: (typeof SCHEDULE_TYPES)[number], color: string) {
     const size = 20;
     if (item.iconSet === 'ionicons')
@@ -70,21 +116,20 @@ export default function RegisterScreen() {
     return <MaterialCommunityIcons name={item.icon as any} size={size} color={color} />;
   }
 
+  const filteredRoutines = routineSearch
+    ? ROUTINES.filter(r => r.title.includes(routineSearch))
+    : ROUTINES;
+
   return (
     <View style={[styles.container, { paddingTop: insets.top }]}>
       {/* Header */}
       <View style={styles.header}>
-        <TouchableOpacity
-          onPress={() => {
-            if (step === 'form') setStep('method');
-            else router.back();
-          }}
-        >
+        <TouchableOpacity onPress={handleBack}>
           <Ionicons name="chevron-back" size={24} color={C.textPrimary} />
         </TouchableOpacity>
         <Text style={styles.headerTitle}>予定を登録</Text>
-        <TouchableOpacity onPress={step === 'form' ? handleSave : undefined}>
-          <Text style={[styles.saveText, step !== 'form' && { opacity: 0.3 }]}>保存</Text>
+        <TouchableOpacity onPress={canSave ? handleSave : undefined}>
+          <Text style={[styles.saveText, !canSave && { opacity: 0.3 }]}>保存</Text>
         </TouchableOpacity>
       </View>
 
@@ -107,17 +152,19 @@ export default function RegisterScreen() {
               <Ionicons name="calendar-outline" size={28} color={C.textPrimary} />
               <Text style={styles.methodText}>新しく登録</Text>
             </TouchableOpacity>
-            <TouchableOpacity style={styles.methodCard}>
+            <TouchableOpacity
+              style={[styles.methodCard, step === 'routine' && styles.methodCardSelected]}
+              onPress={() => setStep('routine')}
+            >
               <MaterialCommunityIcons name="arrow-u-left-top" size={28} color={C.textPrimary} />
               <Text style={styles.methodText}>ルーティンで登録</Text>
             </TouchableOpacity>
           </View>
         </View>
 
-        {/* Form (only visible after selecting method) */}
+        {/* New registration form */}
         {step === 'form' && (
           <>
-            {/* Title */}
             <View style={styles.formCard}>
               <Text style={styles.formLabel}>予定のタイトル</Text>
               <TextInput
@@ -129,7 +176,6 @@ export default function RegisterScreen() {
               />
             </View>
 
-            {/* Memo */}
             <View style={styles.formCard}>
               <Text style={styles.formLabel}>一言メモ</Text>
               <TextInput
@@ -141,7 +187,6 @@ export default function RegisterScreen() {
               />
             </View>
 
-            {/* Schedule type */}
             <View style={styles.section}>
               <Text style={styles.sectionLabel}>予定の種類</Text>
               <View style={styles.typeRow}>
@@ -163,7 +208,6 @@ export default function RegisterScreen() {
               </View>
             </View>
 
-            {/* Belongings */}
             <View style={styles.section}>
               <Text style={styles.sectionLabel}>持ち物</Text>
               <View style={styles.belongingsCard}>
@@ -195,7 +239,6 @@ export default function RegisterScreen() {
               </View>
             </View>
 
-            {/* Departure */}
             <View style={styles.section}>
               <Text style={styles.sectionLabel}>出発地</Text>
               <TouchableOpacity style={styles.departureCard}>
@@ -203,6 +246,61 @@ export default function RegisterScreen() {
                 <Text style={styles.departureText}>自宅</Text>
                 <Ionicons name="chevron-forward" size={18} color={C.textMuted} />
               </TouchableOpacity>
+            </View>
+          </>
+        )}
+
+        {/* Routine selection */}
+        {step === 'routine' && (
+          <>
+            <View style={styles.searchBar}>
+              <Ionicons name="search" size={18} color={C.placeholder} />
+              <TextInput
+                style={styles.searchInput}
+                placeholder="ルーティンを検索"
+                placeholderTextColor={C.placeholder}
+                value={routineSearch}
+                onChangeText={setRoutineSearch}
+              />
+            </View>
+
+            <View style={styles.section}>
+              <Text style={styles.sectionLabel}>ルーティンを選択</Text>
+              {filteredRoutines.map(routine => (
+                <TouchableOpacity
+                  key={routine.id}
+                  style={[
+                    styles.routineCard,
+                    selectedRoutine?.id === routine.id && styles.routineCardSelected,
+                  ]}
+                  onPress={() => handleRoutineSelect(routine)}
+                  activeOpacity={0.7}
+                >
+                  <View style={[styles.routineCardInner, { borderLeftColor: routine.accentColor }]}>
+                    <View style={styles.routineCardContent}>
+                      <Text style={styles.routineCardTitle}>{routine.title}</Text>
+                      <View style={styles.stepsRow}>
+                        {routine.steps.map((s, i) => (
+                          <View key={`${routine.id}-${i}`} style={styles.stepItem}>
+                            <View style={styles.stepDotRow}>
+                              <View
+                                style={[styles.stepDot, { backgroundColor: routine.accentColor }]}
+                              />
+                              {i < routine.steps.length - 1 && (
+                                <View
+                                  style={[styles.stepLine, { backgroundColor: C.stepConnector }]}
+                                />
+                              )}
+                            </View>
+                            <Text style={styles.stepText}>{s}</Text>
+                          </View>
+                        ))}
+                      </View>
+                    </View>
+                    <Ionicons name="chevron-forward" size={21} color={C.textMuted} />
+                  </View>
+                </TouchableOpacity>
+              ))}
             </View>
           </>
         )}
@@ -282,12 +380,7 @@ const styles = StyleSheet.create({
   methodText: { fontSize: 14, fontWeight: '500', color: C.textPrimary },
 
   // Form card
-  formCard: {
-    backgroundColor: C.white,
-    borderRadius: 7,
-    padding: 14,
-    gap: 8,
-  },
+  formCard: { backgroundColor: C.white, borderRadius: 7, padding: 14, gap: 8 },
   formLabel: { fontSize: 14, fontWeight: '500', color: C.textSecondary },
   formInput: { fontSize: 16, fontWeight: '500', color: C.textPrimary, paddingVertical: 4 },
 
@@ -325,11 +418,7 @@ const styles = StyleSheet.create({
     fontSize: 14,
     color: C.textPrimary,
   },
-  addBelongingButton: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 4,
-  },
+  addBelongingButton: { flexDirection: 'row', alignItems: 'center', gap: 4 },
   addBelongingButtonText: { fontSize: 12.25, fontWeight: '500', color: C.primary },
 
   // Departure
@@ -342,6 +431,45 @@ const styles = StyleSheet.create({
     gap: 10,
   },
   departureText: { flex: 1, fontSize: 14, fontWeight: '500', color: C.textPrimary },
+
+  // Search bar
+  searchBar: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: C.white,
+    borderRadius: 7,
+    paddingHorizontal: 12.25,
+    gap: 7,
+    height: 40,
+  },
+  searchInput: { flex: 1, fontSize: 14, fontWeight: '400', color: C.textPrimary },
+
+  // Routine cards
+  routineCard: {
+    borderWidth: 1,
+    borderColor: C.border,
+    borderRadius: 7,
+    overflow: 'hidden',
+  },
+  routineCardSelected: { borderColor: C.primary, borderWidth: 2 },
+  routineCardInner: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    borderLeftWidth: 6,
+    borderRadius: 7,
+    paddingVertical: 12.25,
+    paddingHorizontal: 17.5,
+    gap: 8,
+  },
+  routineCardContent: { flex: 1, gap: 12.25 },
+  routineCardTitle: { fontSize: 14, fontWeight: '700', color: C.textPrimary },
+  stepsRow: { flexDirection: 'row', gap: 8 },
+  stepItem: { alignItems: 'center', gap: 7 },
+  stepDotRow: { flexDirection: 'row', alignItems: 'center' },
+  stepDot: { width: 12.25, height: 12.25, borderRadius: 6.125 },
+  stepLine: { width: 68, height: 2 },
+  stepText: { fontSize: 14, fontWeight: '500', color: C.textSecondary },
 
   // Modal
   modalOverlay: {

--- a/frontend/app/schedule/register.tsx
+++ b/frontend/app/schedule/register.tsx
@@ -73,17 +73,20 @@ export default function RegisterScreen() {
   const [belongings, setBelongings] = useState<string[]>(['財布', '充電器']);
   const [newBelonging, setNewBelonging] = useState('');
   const [showModal, setShowModal] = useState(false);
-  const [selectedRoutine, setSelectedRoutine] = useState<Routine | null>(null);
-  const [routineSearch, setRoutineSearch] = useState('');
+  const [selectedRoutine, setSelectedRoutine] = useState<Routine>(ROUTINES[0]);
+  const [showRoutinePicker, setShowRoutinePicker] = useState(false);
+  const [routineBelongings, setRoutineBelongings] = useState<string[]>([]);
+  const [newRoutineBelonging, setNewRoutineBelonging] = useState('');
 
   function handleSave() {
     setShowModal(true);
   }
 
-  function handleRoutineSelect(routine: Routine) {
-    setSelectedRoutine(routine);
-    setTitle(routine.title);
-    setShowModal(true);
+  function addRoutineBelonging() {
+    if (newRoutineBelonging.trim()) {
+      setRoutineBelongings(prev => [...prev, newRoutineBelonging.trim()]);
+      setNewRoutineBelonging('');
+    }
   }
 
   function removeBelonging(index: number) {
@@ -100,13 +103,13 @@ export default function RegisterScreen() {
   function handleBack() {
     if (step === 'form' || step === 'routine') {
       setStep('method');
-      setSelectedRoutine(null);
+      setSelectedRoutine(ROUTINES[0]);
     } else {
       router.back();
     }
   }
 
-  const canSave = step === 'form' || (step === 'routine' && selectedRoutine);
+  const canSave = step === 'form' || step === 'routine';
 
   function renderTypeIcon(item: (typeof SCHEDULE_TYPES)[number], color: string) {
     const size = 20;
@@ -115,10 +118,6 @@ export default function RegisterScreen() {
     if (item.iconSet === 'fa5') return <FontAwesome5 name={item.icon} size={size} color={color} />;
     return <MaterialCommunityIcons name={item.icon as any} size={size} color={color} />;
   }
-
-  const filteredRoutines = routineSearch
-    ? ROUTINES.filter(r => r.title.includes(routineSearch))
-    : ROUTINES;
 
   return (
     <View style={[styles.container, { paddingTop: insets.top }]}>
@@ -153,11 +152,17 @@ export default function RegisterScreen() {
               <Text style={styles.methodText}>新しく登録</Text>
             </TouchableOpacity>
             <TouchableOpacity
-              style={[styles.methodCard, step === 'routine' && styles.methodCardSelected]}
+              style={[styles.methodCard, step === 'routine' && styles.methodCardRoutineSelected]}
               onPress={() => setStep('routine')}
             >
-              <MaterialCommunityIcons name="arrow-u-left-top" size={28} color={C.textPrimary} />
-              <Text style={styles.methodText}>ルーティンで登録</Text>
+              <MaterialCommunityIcons
+                name="arrow-u-left-top"
+                size={28}
+                color={step === 'routine' ? C.textPrimary : C.textPrimary}
+              />
+              <Text style={[styles.methodText, step === 'routine' && { fontWeight: '700' }]}>
+                ルーティンで登録
+              </Text>
             </TouchableOpacity>
           </View>
         </View>
@@ -250,61 +255,129 @@ export default function RegisterScreen() {
           </>
         )}
 
-        {/* Routine selection */}
+        {/* Routine registration */}
         {step === 'routine' && (
           <>
-            <View style={styles.searchBar}>
-              <Ionicons name="search" size={18} color={C.placeholder} />
-              <TextInput
-                style={styles.searchInput}
-                placeholder="ルーティンを検索"
-                placeholderTextColor={C.placeholder}
-                value={routineSearch}
-                onChangeText={setRoutineSearch}
-              />
+            {/* Selected routine */}
+            <View style={styles.section}>
+              <Text style={styles.sectionLabel}>ルーティン</Text>
+              <TouchableOpacity
+                style={styles.selectedRoutineCard}
+                onPress={() => setShowRoutinePicker(true)}
+                activeOpacity={0.7}
+              >
+                <View style={styles.selectedRoutineInner}>
+                  <View style={styles.selectedRoutineRow}>
+                    <Ionicons name="briefcase-outline" size={21} color={C.accent} />
+                    <Text style={styles.selectedRoutineTitle}>{selectedRoutine.title}</Text>
+                  </View>
+                  <Ionicons name="chevron-forward" size={21} color={C.textMuted} />
+                </View>
+              </TouchableOpacity>
             </View>
 
+            {/* Belongings for routine */}
             <View style={styles.section}>
-              <Text style={styles.sectionLabel}>ルーティンを選択</Text>
-              {filteredRoutines.map(routine => (
-                <TouchableOpacity
-                  key={routine.id}
-                  style={[
-                    styles.routineCard,
-                    selectedRoutine?.id === routine.id && styles.routineCardSelected,
-                  ]}
-                  onPress={() => handleRoutineSelect(routine)}
-                  activeOpacity={0.7}
-                >
-                  <View style={[styles.routineCardInner, { borderLeftColor: routine.accentColor }]}>
-                    <View style={styles.routineCardContent}>
-                      <Text style={styles.routineCardTitle}>{routine.title}</Text>
-                      <View style={styles.stepsRow}>
-                        {routine.steps.map((s, i) => (
-                          <View key={`${routine.id}-${i}`} style={styles.stepItem}>
-                            <View style={styles.stepDotRow}>
-                              <View
-                                style={[styles.stepDot, { backgroundColor: routine.accentColor }]}
-                              />
-                              {i < routine.steps.length - 1 && (
-                                <View
-                                  style={[styles.stepLine, { backgroundColor: C.stepConnector }]}
-                                />
-                              )}
-                            </View>
-                            <Text style={styles.stepText}>{s}</Text>
-                          </View>
-                        ))}
+              <Text style={styles.sectionLabel}>持ち物</Text>
+              <View style={styles.belongingsCard}>
+                {routineBelongings.length > 0 ? (
+                  routineBelongings.map((item, i) => (
+                    <View key={`rb-${i}`}>
+                      <View style={styles.belongingRow}>
+                        <Text style={styles.belongingText}>{item}</Text>
+                        <TouchableOpacity
+                          onPress={() =>
+                            setRoutineBelongings(prev => prev.filter((_, idx) => idx !== i))
+                          }
+                        >
+                          <Ionicons name="remove-circle" size={22} color="#E57373" />
+                        </TouchableOpacity>
                       </View>
+                      {i < routineBelongings.length - 1 && <View style={styles.belongingDivider} />}
                     </View>
-                    <Ionicons name="chevron-forward" size={21} color={C.textMuted} />
-                  </View>
+                  ))
+                ) : (
+                  <TextInput
+                    style={styles.formInput}
+                    placeholder="例：名刺"
+                    placeholderTextColor={C.placeholder}
+                    value={newRoutineBelonging}
+                    onChangeText={setNewRoutineBelonging}
+                    onSubmitEditing={addRoutineBelonging}
+                  />
+                )}
+              </View>
+              <View style={styles.addBelongingRowEnd}>
+                <TouchableOpacity
+                  style={styles.addBelongingButton}
+                  onPress={() => {
+                    if (routineBelongings.length === 0 && newRoutineBelonging.trim()) {
+                      addRoutineBelonging();
+                    } else {
+                      setRoutineBelongings(prev => [...prev, '']);
+                    }
+                  }}
+                >
+                  <Ionicons name="add" size={16} color={C.primary} />
+                  <Text style={styles.addBelongingButtonText}>持ち物を追加</Text>
                 </TouchableOpacity>
-              ))}
+              </View>
             </View>
           </>
         )}
       </ScrollView>
+
+      {/* Routine Picker Modal */}
+      <Modal visible={showRoutinePicker} transparent animationType="slide">
+        <View style={styles.pickerOverlay}>
+          <View style={styles.pickerContent}>
+            <View style={styles.pickerHeader}>
+              <Text style={styles.pickerTitle}>ルーティンを選択</Text>
+              <TouchableOpacity onPress={() => setShowRoutinePicker(false)}>
+                <Ionicons name="close" size={24} color={C.textPrimary} />
+              </TouchableOpacity>
+            </View>
+            <ScrollView style={styles.pickerScroll}>
+              {ROUTINES.map(routine => (
+                <TouchableOpacity
+                  key={routine.id}
+                  style={[
+                    styles.pickerRoutineCard,
+                    selectedRoutine.id === routine.id && styles.pickerRoutineCardSelected,
+                  ]}
+                  onPress={() => {
+                    setSelectedRoutine(routine);
+                    setShowRoutinePicker(false);
+                  }}
+                >
+                  <View
+                    style={[styles.pickerRoutineInner, { borderLeftColor: routine.accentColor }]}
+                  >
+                    <Text style={styles.pickerRoutineTitle}>{routine.title}</Text>
+                    <View style={styles.stepsRow}>
+                      {routine.steps.map((s, i) => (
+                        <View key={`pick-${routine.id}-${i}`} style={styles.stepItem}>
+                          <View style={styles.stepDotRow}>
+                            <View
+                              style={[styles.stepDot, { backgroundColor: routine.accentColor }]}
+                            />
+                            {i < routine.steps.length - 1 && (
+                              <View
+                                style={[styles.stepLine, { backgroundColor: C.stepConnector }]}
+                              />
+                            )}
+                          </View>
+                          <Text style={styles.stepText}>{s}</Text>
+                        </View>
+                      ))}
+                    </View>
+                  </View>
+                </TouchableOpacity>
+              ))}
+            </ScrollView>
+          </View>
+        </View>
+      </Modal>
 
       {/* Success Modal */}
       <Modal visible={showModal} transparent animationType="fade">
@@ -377,6 +450,7 @@ const styles = StyleSheet.create({
     gap: 7,
   },
   methodCardSelected: { borderWidth: 2, borderColor: C.primary },
+  methodCardRoutineSelected: { backgroundColor: '#E6EDF6', borderWidth: 1, borderColor: C.primary },
   methodText: { fontSize: 14, fontWeight: '500', color: C.textPrimary },
 
   // Form card
@@ -432,38 +506,59 @@ const styles = StyleSheet.create({
   },
   departureText: { flex: 1, fontSize: 14, fontWeight: '500', color: C.textPrimary },
 
-  // Search bar
-  searchBar: {
+  // Selected routine card
+  selectedRoutineCard: {
+    backgroundColor: C.white,
+    borderRadius: 10.5,
+    overflow: 'hidden',
+  },
+  selectedRoutineInner: {
     flexDirection: 'row',
     alignItems: 'center',
-    backgroundColor: C.white,
-    borderRadius: 7,
-    paddingHorizontal: 12.25,
-    gap: 7,
-    height: 40,
+    justifyContent: 'space-between',
+    padding: 14,
   },
-  searchInput: { flex: 1, fontSize: 14, fontWeight: '400', color: C.textPrimary },
+  selectedRoutineRow: { flexDirection: 'row', alignItems: 'center', gap: 10.5, flex: 1 },
+  selectedRoutineTitle: { fontSize: 14, fontWeight: '700', color: C.textPrimary },
+  addBelongingRowEnd: { alignItems: 'flex-end' },
 
-  // Routine cards
-  routineCard: {
+  // Routine picker modal
+  pickerOverlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.4)',
+    justifyContent: 'flex-end',
+  },
+  pickerContent: {
+    backgroundColor: C.white,
+    borderTopLeftRadius: 14,
+    borderTopRightRadius: 14,
+    maxHeight: '70%',
+    padding: 20,
+  },
+  pickerHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 16,
+  },
+  pickerTitle: { fontSize: 17.5, fontWeight: '700', color: C.textPrimary },
+  pickerScroll: { gap: 12 },
+  pickerRoutineCard: {
     borderWidth: 1,
     borderColor: C.border,
     borderRadius: 7,
     overflow: 'hidden',
+    marginBottom: 12,
   },
-  routineCardSelected: { borderColor: C.primary, borderWidth: 2 },
-  routineCardInner: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
+  pickerRoutineCardSelected: { borderColor: C.primary, borderWidth: 2 },
+  pickerRoutineInner: {
     borderLeftWidth: 6,
     borderRadius: 7,
     paddingVertical: 12.25,
     paddingHorizontal: 17.5,
-    gap: 8,
+    gap: 12.25,
   },
-  routineCardContent: { flex: 1, gap: 12.25 },
-  routineCardTitle: { fontSize: 14, fontWeight: '700', color: C.textPrimary },
+  pickerRoutineTitle: { fontSize: 14, fontWeight: '700', color: C.textPrimary },
   stepsRow: { flexDirection: 'row', gap: 8 },
   stepItem: { alignItems: 'center', gap: 7 },
   stepDotRow: { flexDirection: 'row', alignItems: 'center' },


### PR DESCRIPTION
## Summary
- Figmaデザイン3画面（node: 2617-2938, 2631-3062, 2636-3688）に基づき、予定登録フローを実装
- 予定リスト画面: チャットバブル、準備チェックリスト、天気・電車カード、ルーティンカード、登録CTA
- 予定登録画面: 登録方法選択（新規/ルーティン）→ フォーム入力（タイトル、メモ、種類、持ち物、出発地）
- 登録完了モーダル: 成功メッセージ + スケジュール作成への導線

## 変更ファイル
- `frontend/app/_layout.tsx` - root layoutにscheduleルート追加
- `frontend/app/schedule/_layout.tsx` - Stackナビゲーション（新規）
- `frontend/app/schedule/index.tsx` - 予定リスト画面（新規）
- `frontend/app/schedule/register.tsx` - 予定登録画面（新規）

## Test plan
- [ ] `pnpm dev` でExpo開発サーバーが起動すること
- [ ] 予定リスト画面が表示されること
- [ ] 「登録」ボタンで予定登録画面へ遷移すること
- [ ] 「新しく登録」選択でフォームが表示されること
- [ ] 予定の種類（休日/旅行/仕事/出張）の選択切替が動作すること
- [ ] 持ち物の追加・削除が動作すること
- [ ] 「保存」で完了モーダルが表示されること
- [ ] 「閉じる」で元の画面に戻ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)