### PR TITLE
fix: CORS設定を全環境で有効化

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -24,14 +24,13 @@ from app.exceptions import (
 
 app = FastAPI(title="Tenichi API")
 
-if settings.ENVIRONMENT == "development":
-    app.add_middleware(
-        CORSMiddleware,
-        allow_origins=["*"],
-        allow_credentials=True,
-        allow_methods=["*"],
-        allow_headers=["*"],
-    )
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 app.add_exception_handler(AppError, app_error_handler)  # type: ignore[arg-type]
 app.add_exception_handler(RequestValidationError, validation_error_handler)  # type: ignore[arg-type]

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -14,7 +14,6 @@ from app.api.tags import router as tags_router
 from app.api.templates import router as templates_router
 from app.api.users import router as users_router
 from app.api.weather import router as weather_router
-from app.config import settings
 from app.exceptions import (
     AppError,
     app_error_handler,

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -14,6 +14,7 @@ from app.api.tags import router as tags_router
 from app.api.templates import router as templates_router
 from app.api.users import router as users_router
 from app.api.weather import router as weather_router
+from app.config import settings
 from app.exceptions import (
     AppError,
     app_error_handler,
@@ -23,9 +24,18 @@ from app.exceptions import (
 
 app = FastAPI(title="Tenichi API")
 
+_ALLOWED_ORIGINS = (
+    ["*"]
+    if settings.ENVIRONMENT == "development"
+    else [
+        "http://localhost:8081",
+        "https://schedule-t-y-k-app.web.app",
+    ]
+)
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=_ALLOWED_ORIGINS,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],


### PR DESCRIPTION
## Summary
- フロントエンド(Expo Web localhost:8081)からCloud Run上のAPIにアクセスする際、本番環境ではCORSミドルウェアが無効のためブラウザがリクエストをブロックしていた
- `settings.ENVIRONMENT == "development"` の条件を削除し、全環境でCORSを有効化

## Test plan
- [ ] Cloud Runにデプロイ後、ブラウザ(localhost:8081)から`/api/v1/auth/login`にCORSエラーなくアクセスできること
- [ ] `/api/v1/routes/search` にブラウザからPOSTリクエストが通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)