### PR TITLE
feat: ログイン画面・サインアップ画面を実装

### DIFF
--- a/frontend/app/_layout.tsx
+++ b/frontend/app/_layout.tsx
@@ -15,6 +15,7 @@ export default function RootLayout() {
   return (
     <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
       <Stack>
+        <Stack.Screen name="auth" options={{ headerShown: false }} />
         <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
         <Stack.Screen name="schedule" options={{ headerShown: false }} />
         <Stack.Screen name="modal" options={{ presentation: 'modal', title: 'Modal' }} />

--- a/frontend/app/auth/_layout.tsx
+++ b/frontend/app/auth/_layout.tsx
@@ -1,0 +1,10 @@
+import { Stack } from 'expo-router';
+
+export default function AuthLayout() {
+  return (
+    <Stack screenOptions={{ headerShown: false }}>
+      <Stack.Screen name="login" />
+      <Stack.Screen name="register" />
+    </Stack>
+  );
+}

--- a/frontend/app/auth/login.tsx
+++ b/frontend/app/auth/login.tsx
@@ -1,0 +1,320 @@
+import React, { useState } from 'react';
+import {
+  ActivityIndicator,
+  KeyboardAvoidingView,
+  Platform,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useRouter } from 'expo-router';
+import { Ionicons } from '@expo/vector-icons';
+
+const C = {
+  primary: '#436F9B',
+  white: '#FFFFFF',
+  textPrimary: '#1F2528',
+  textSecondary: '#63747E',
+  textMuted: '#B5BFC5',
+  bg: '#EEF0F1',
+  placeholder: '#98A6AE',
+  error: '#D94040',
+};
+
+const BASE_URL = 'https://fastapi-backend-825512055944.asia-northeast1.run.app/api/v1';
+
+export default function LoginScreen() {
+  const insets = useSafeAreaInsets();
+  const router = useRouter();
+
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [showPassword, setShowPassword] = useState(false);
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  async function handleLogin() {
+    setError('');
+
+    // Validation
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailRegex.test(email)) {
+      setError('メールアドレスのフォーマットにしてください。');
+      return;
+    }
+    if (!password) {
+      setError('パスワードを入力してください。');
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const res = await fetch(`${BASE_URL}/auth/login`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, password }),
+      });
+
+      if (!res.ok) {
+        if (res.status === 401) {
+          setError('メールアドレスまたはパスワードが違います。');
+        } else {
+          setError('予期せぬエラーが発生しました。しばらく待って再度試してください。');
+        }
+        return;
+      }
+
+      const data = await res.json();
+      // TODO: AsyncStorageにトークンを保存する
+      // await AsyncStorage.setItem('access_token', data.access_token);
+      // await AsyncStorage.setItem('refresh_token', data.refresh_token);
+
+      router.replace('/(tabs)');
+    } catch {
+      setError('予期せぬエラーが発生しました。しばらく待って再度試してください。');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <View style={styles.container}>
+      <KeyboardAvoidingView
+        style={styles.flex}
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+      >
+        <ScrollView
+          contentContainerStyle={styles.scrollContent}
+          keyboardShouldPersistTaps="handled"
+          showsVerticalScrollIndicator={false}
+        >
+          {/* Header */}
+          <View style={[styles.header, { paddingTop: insets.top + 40 }]}>
+            <View style={styles.iconCircle}>
+              <Ionicons name="person" size={36} color={C.white} />
+            </View>
+            <Text style={styles.appName}>セバス・ホー</Text>
+            <Text style={styles.subtitle}>あなたの毎日をサポートする執事</Text>
+          </View>
+
+          {/* Form */}
+          <View style={styles.formCard}>
+            <Text style={styles.formTitle}>ログイン</Text>
+
+            {error ? (
+              <View style={styles.errorBox}>
+                <Ionicons name="alert-circle" size={16} color={C.error} />
+                <Text style={styles.errorText}>{error}</Text>
+              </View>
+            ) : null}
+
+            <View style={styles.inputGroup}>
+              <Text style={styles.label}>メールアドレス</Text>
+              <TextInput
+                style={styles.input}
+                placeholder="example@email.com"
+                placeholderTextColor={C.placeholder}
+                keyboardType="email-address"
+                autoCapitalize="none"
+                autoComplete="email"
+                value={email}
+                onChangeText={setEmail}
+              />
+            </View>
+
+            <View style={styles.inputGroup}>
+              <Text style={styles.label}>パスワード</Text>
+              <View style={styles.passwordRow}>
+                <TextInput
+                  style={[styles.input, styles.passwordInput]}
+                  placeholder="パスワードを入力"
+                  placeholderTextColor={C.placeholder}
+                  secureTextEntry={!showPassword}
+                  autoCapitalize="none"
+                  value={password}
+                  onChangeText={setPassword}
+                />
+                <TouchableOpacity
+                  style={styles.eyeButton}
+                  onPress={() => setShowPassword(!showPassword)}
+                >
+                  <Ionicons
+                    name={showPassword ? 'eye-off' : 'eye'}
+                    size={20}
+                    color={C.textMuted}
+                  />
+                </TouchableOpacity>
+              </View>
+            </View>
+
+            <TouchableOpacity
+              style={[styles.button, loading && styles.buttonDisabled]}
+              onPress={handleLogin}
+              disabled={loading}
+              activeOpacity={0.7}
+            >
+              {loading ? (
+                <ActivityIndicator color={C.white} />
+              ) : (
+                <Text style={styles.buttonText}>ログイン</Text>
+              )}
+            </TouchableOpacity>
+
+            <TouchableOpacity
+              style={styles.linkButton}
+              onPress={() => router.push('/auth/register')}
+            >
+              <Text style={styles.linkText}>
+                アカウントをお持ちでない方は
+                <Text style={styles.linkTextBold}> サインアップ</Text>
+              </Text>
+            </TouchableOpacity>
+          </View>
+        </ScrollView>
+      </KeyboardAvoidingView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: C.primary,
+  },
+  flex: {
+    flex: 1,
+  },
+  scrollContent: {
+    flexGrow: 1,
+  },
+
+  // Header
+  header: {
+    alignItems: 'center',
+    paddingBottom: 32,
+    paddingHorizontal: 14,
+  },
+  iconCircle: {
+    width: 72,
+    height: 72,
+    borderRadius: 36,
+    backgroundColor: 'rgba(255,255,255,0.25)',
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginBottom: 14,
+  },
+  appName: {
+    fontSize: 28,
+    fontWeight: '700',
+    color: C.white,
+    marginBottom: 6,
+  },
+  subtitle: {
+    fontSize: 14,
+    fontWeight: '400',
+    color: 'rgba(255,255,255,0.8)',
+  },
+
+  // Form
+  formCard: {
+    flex: 1,
+    backgroundColor: C.white,
+    borderTopLeftRadius: 20,
+    borderTopRightRadius: 20,
+    paddingHorizontal: 24,
+    paddingTop: 32,
+    paddingBottom: 40,
+  },
+  formTitle: {
+    fontSize: 20,
+    fontWeight: '700',
+    color: C.textPrimary,
+    marginBottom: 24,
+  },
+
+  // Error
+  errorBox: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    backgroundColor: '#FEF2F2',
+    borderRadius: 7,
+    padding: 12,
+    marginBottom: 16,
+  },
+  errorText: {
+    flex: 1,
+    fontSize: 13,
+    fontWeight: '500',
+    color: C.error,
+  },
+
+  // Input
+  inputGroup: {
+    marginBottom: 20,
+  },
+  label: {
+    fontSize: 13,
+    fontWeight: '600',
+    color: C.textSecondary,
+    marginBottom: 8,
+  },
+  input: {
+    height: 48,
+    borderWidth: 1,
+    borderColor: C.bg,
+    borderRadius: 7,
+    paddingHorizontal: 14,
+    fontSize: 15,
+    color: C.textPrimary,
+    backgroundColor: C.white,
+  },
+  passwordRow: {
+    position: 'relative',
+  },
+  passwordInput: {
+    paddingRight: 48,
+  },
+  eyeButton: {
+    position: 'absolute',
+    right: 14,
+    top: 14,
+  },
+
+  // Button
+  button: {
+    height: 50,
+    backgroundColor: C.primary,
+    borderRadius: 7,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginTop: 8,
+  },
+  buttonDisabled: {
+    opacity: 0.6,
+  },
+  buttonText: {
+    fontSize: 16,
+    fontWeight: '700',
+    color: C.white,
+  },
+
+  // Link
+  linkButton: {
+    alignItems: 'center',
+    marginTop: 20,
+    padding: 8,
+  },
+  linkText: {
+    fontSize: 14,
+    color: C.textSecondary,
+  },
+  linkTextBold: {
+    fontWeight: '700',
+    color: C.primary,
+  },
+});

--- a/frontend/app/auth/login.tsx
+++ b/frontend/app/auth/login.tsx
@@ -13,6 +13,7 @@ import {
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useRouter } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
+import { BASE_URL, setToken } from '@/lib/api-client';
 
 const C = {
   primary: '#436F9B',
@@ -24,8 +25,6 @@ const C = {
   placeholder: '#98A6AE',
   error: '#D94040',
 };
-
-const BASE_URL = 'https://fastapi-backend-825512055944.asia-northeast1.run.app/api/v1';
 
 export default function LoginScreen() {
   const insets = useSafeAreaInsets();
@@ -68,10 +67,8 @@ export default function LoginScreen() {
         return;
       }
 
-      const data = await res.json();
-      // TODO: AsyncStorageにトークンを保存する
-      // await AsyncStorage.setItem('access_token', data.access_token);
-      // await AsyncStorage.setItem('refresh_token', data.refresh_token);
+      const { access_token } = await res.json();
+      setToken(access_token);
 
       router.replace('/(tabs)');
     } catch {
@@ -142,11 +139,7 @@ export default function LoginScreen() {
                   style={styles.eyeButton}
                   onPress={() => setShowPassword(!showPassword)}
                 >
-                  <Ionicons
-                    name={showPassword ? 'eye-off' : 'eye'}
-                    size={20}
-                    color={C.textMuted}
-                  />
+                  <Ionicons name={showPassword ? 'eye-off' : 'eye'} size={20} color={C.textMuted} />
                 </TouchableOpacity>
               </View>
             </View>

--- a/frontend/app/auth/register.tsx
+++ b/frontend/app/auth/register.tsx
@@ -11,8 +11,9 @@ import {
   View,
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { useRouter } from 'expo-router';
+import { useRouter, useLocalSearchParams } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
+import { BASE_URL, setToken } from '@/lib/api-client';
 
 const C = {
   primary: '#436F9B',
@@ -24,8 +25,6 @@ const C = {
   placeholder: '#98A6AE',
   error: '#D94040',
 };
-
-const BASE_URL = 'https://fastapi-backend-825512055944.asia-northeast1.run.app/api/v1';
 
 type FieldErrors = {
   email?: string;
@@ -41,6 +40,7 @@ function validate(fields: {
   name: string;
   preparationMinutes: string;
   homeAddress: string;
+  homeLat: number | null;
 }): FieldErrors {
   const errors: FieldErrors = {};
   const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
@@ -49,7 +49,6 @@ function validate(fields: {
     errors.email = 'メールアドレスのフォーマットにしてください。';
   }
 
-  // Password: 英数字2種以上 & 8文字以上100文字以下
   const hasLetter = /[a-zA-Z]/.test(fields.password);
   const hasDigit = /\d/.test(fields.password);
   if (fields.password.length < 8 || fields.password.length > 100 || !hasLetter || !hasDigit) {
@@ -65,8 +64,12 @@ function validate(fields: {
     errors.preparation_minutes = '身支度時間を正しく入力してください。';
   }
 
-  if (fields.homeAddress.length < 1 || fields.homeAddress.length > 200) {
-    errors.home_address = '住所は1文字以上200文字以下にしてください。';
+  if (!fields.homeAddress || fields.homeAddress.length > 200) {
+    errors.home_address = '住所を選択してください。';
+  }
+
+  if (fields.homeLat === null) {
+    errors.home_address = 'マップから住所を選択してください。';
   }
 
   return errors;
@@ -75,13 +78,22 @@ function validate(fields: {
 export default function RegisterScreen() {
   const insets = useSafeAreaInsets();
   const router = useRouter();
+  const params = useLocalSearchParams<{
+    home_lat?: string;
+    home_lon?: string;
+    home_address?: string;
+  }>();
 
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [showPassword, setShowPassword] = useState(false);
   const [name, setName] = useState('');
   const [preparationMinutes, setPreparationMinutes] = useState('');
-  const [homeAddress, setHomeAddress] = useState('');
+
+  // 住所はマップピッカーから受け取る
+  const homeAddress = params.home_address ?? '';
+  const homeLat = params.home_lat ? parseFloat(params.home_lat) : null;
+  const homeLon = params.home_lon ? parseFloat(params.home_lon) : null;
 
   const [fieldErrors, setFieldErrors] = useState<FieldErrors>({});
   const [apiError, setApiError] = useState('');
@@ -98,7 +110,14 @@ export default function RegisterScreen() {
     setApiError('');
     setFieldErrors({});
 
-    const errors = validate({ email, password, name, preparationMinutes, homeAddress });
+    const errors = validate({
+      email,
+      password,
+      name,
+      preparationMinutes,
+      homeAddress,
+      homeLat,
+    });
     if (Object.keys(errors).length > 0) {
       setFieldErrors(errors);
       return;
@@ -114,29 +133,27 @@ export default function RegisterScreen() {
           password,
           name,
           home_address: homeAddress,
-          home_lat: 35.6762, // TODO: 住所からジオコーディング
-          home_lon: 139.6503,
+          home_lat: homeLat,
+          home_lon: homeLon,
           preparation_minutes: Number(preparationMinutes),
           reminder_minutes_before: 5,
         }),
       });
 
       if (!res.ok) {
-        const data = await res.json().catch(() => null);
+        const errorData = await res.json().catch(() => null);
         if (res.status === 409) {
           setApiError('このメールアドレスは既に登録されています。');
-        } else if (data?.detail) {
-          setApiError(data.detail);
+        } else if (errorData?.detail) {
+          setApiError(errorData.detail);
         } else {
           setApiError('予期せぬエラーが発生しました。しばらく待って再度試してください。');
         }
         return;
       }
 
-      const data = await res.json();
-      // TODO: AsyncStorageにトークンを保存する
-      // await AsyncStorage.setItem('access_token', data.access_token);
-      // await AsyncStorage.setItem('refresh_token', data.refresh_token);
+      const { access_token } = await res.json();
+      setToken(access_token);
 
       router.replace('/(tabs)/calendar');
     } catch {
@@ -156,7 +173,7 @@ export default function RegisterScreen() {
       keyboardType?: 'default' | 'email-address' | 'numeric';
       secureTextEntry?: boolean;
       autoCapitalize?: 'none' | 'sentences';
-    },
+    }
   ) {
     const err = options.errorKey ? fieldErrors[options.errorKey] : undefined;
     const isPassword = options.secureTextEntry;
@@ -245,10 +262,35 @@ export default function RegisterScreen() {
               keyboardType: 'numeric',
             })}
 
-            {renderInput('自宅住所', homeAddress, setHomeAddress, {
-              placeholder: '住所を入力',
-              errorKey: 'home_address',
-            })}
+            {/* 住所選択 - マップピッカーで選択 */}
+            <View style={styles.inputGroup}>
+              <Text style={styles.label}>自宅住所</Text>
+              <TouchableOpacity
+                style={[styles.addressButton, fieldErrors.home_address && styles.inputError]}
+                onPress={() =>
+                  router.push({
+                    pathname: '/schedule/destination-picker',
+                    params: { returnTo: 'auth/register' },
+                  })
+                }
+              >
+                <Ionicons
+                  name="location"
+                  size={18}
+                  color={homeAddress ? C.primary : C.placeholder}
+                />
+                <Text
+                  style={[styles.addressText, !homeAddress && styles.addressPlaceholder]}
+                  numberOfLines={1}
+                >
+                  {homeAddress || 'マップから住所を選択'}
+                </Text>
+                <Ionicons name="chevron-forward" size={16} color={C.textMuted} />
+              </TouchableOpacity>
+              {fieldErrors.home_address && (
+                <Text style={styles.fieldError}>{fieldErrors.home_address}</Text>
+              )}
+            </View>
 
             <TouchableOpacity
               style={[styles.button, (!allFilled || loading) && styles.buttonDisabled]}
@@ -387,6 +429,27 @@ const styles = StyleSheet.create({
     fontSize: 12,
     color: C.error,
     marginTop: 4,
+  },
+
+  // Address picker button
+  addressButton: {
+    height: 48,
+    borderWidth: 1,
+    borderColor: C.bg,
+    borderRadius: 7,
+    paddingHorizontal: 14,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    backgroundColor: C.white,
+  },
+  addressText: {
+    flex: 1,
+    fontSize: 15,
+    color: C.textPrimary,
+  },
+  addressPlaceholder: {
+    color: C.placeholder,
   },
 
   // Button

--- a/frontend/app/auth/register.tsx
+++ b/frontend/app/auth/register.tsx
@@ -1,0 +1,424 @@
+import React, { useState } from 'react';
+import {
+  ActivityIndicator,
+  KeyboardAvoidingView,
+  Platform,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useRouter } from 'expo-router';
+import { Ionicons } from '@expo/vector-icons';
+
+const C = {
+  primary: '#436F9B',
+  white: '#FFFFFF',
+  textPrimary: '#1F2528',
+  textSecondary: '#63747E',
+  textMuted: '#B5BFC5',
+  bg: '#EEF0F1',
+  placeholder: '#98A6AE',
+  error: '#D94040',
+};
+
+const BASE_URL = 'https://fastapi-backend-825512055944.asia-northeast1.run.app/api/v1';
+
+type FieldErrors = {
+  email?: string;
+  password?: string;
+  name?: string;
+  preparation_minutes?: string;
+  home_address?: string;
+};
+
+function validate(fields: {
+  email: string;
+  password: string;
+  name: string;
+  preparationMinutes: string;
+  homeAddress: string;
+}): FieldErrors {
+  const errors: FieldErrors = {};
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+  if (!emailRegex.test(fields.email)) {
+    errors.email = 'メールアドレスのフォーマットにしてください。';
+  }
+
+  // Password: 英数字2種以上 & 8文字以上100文字以下
+  const hasLetter = /[a-zA-Z]/.test(fields.password);
+  const hasDigit = /\d/.test(fields.password);
+  if (fields.password.length < 8 || fields.password.length > 100 || !hasLetter || !hasDigit) {
+    errors.password = 'パスワードは英数字2種類以上かつ8文字以上100文字以下にしてください。';
+  }
+
+  if (fields.name.length < 1 || fields.name.length > 20) {
+    errors.name = 'ユーザー名は1文字以上20文字以下にしてください。';
+  }
+
+  const minutes = Number(fields.preparationMinutes);
+  if (!fields.preparationMinutes || isNaN(minutes) || minutes < 0) {
+    errors.preparation_minutes = '身支度時間を正しく入力してください。';
+  }
+
+  if (fields.homeAddress.length < 1 || fields.homeAddress.length > 200) {
+    errors.home_address = '住所は1文字以上200文字以下にしてください。';
+  }
+
+  return errors;
+}
+
+export default function RegisterScreen() {
+  const insets = useSafeAreaInsets();
+  const router = useRouter();
+
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [showPassword, setShowPassword] = useState(false);
+  const [name, setName] = useState('');
+  const [preparationMinutes, setPreparationMinutes] = useState('');
+  const [homeAddress, setHomeAddress] = useState('');
+
+  const [fieldErrors, setFieldErrors] = useState<FieldErrors>({});
+  const [apiError, setApiError] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const allFilled =
+    email.length > 0 &&
+    password.length > 0 &&
+    name.length > 0 &&
+    preparationMinutes.length > 0 &&
+    homeAddress.length > 0;
+
+  async function handleRegister() {
+    setApiError('');
+    setFieldErrors({});
+
+    const errors = validate({ email, password, name, preparationMinutes, homeAddress });
+    if (Object.keys(errors).length > 0) {
+      setFieldErrors(errors);
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const res = await fetch(`${BASE_URL}/auth/register`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          email,
+          password,
+          name,
+          home_address: homeAddress,
+          home_lat: 35.6762, // TODO: 住所からジオコーディング
+          home_lon: 139.6503,
+          preparation_minutes: Number(preparationMinutes),
+          reminder_minutes_before: 5,
+        }),
+      });
+
+      if (!res.ok) {
+        const data = await res.json().catch(() => null);
+        if (res.status === 409) {
+          setApiError('このメールアドレスは既に登録されています。');
+        } else if (data?.detail) {
+          setApiError(data.detail);
+        } else {
+          setApiError('予期せぬエラーが発生しました。しばらく待って再度試してください。');
+        }
+        return;
+      }
+
+      const data = await res.json();
+      // TODO: AsyncStorageにトークンを保存する
+      // await AsyncStorage.setItem('access_token', data.access_token);
+      // await AsyncStorage.setItem('refresh_token', data.refresh_token);
+
+      router.replace('/(tabs)/calendar');
+    } catch {
+      setApiError('予期せぬエラーが発生しました。しばらく待って再度試してください。');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function renderInput(
+    label: string,
+    value: string,
+    onChangeText: (v: string) => void,
+    options: {
+      placeholder: string;
+      errorKey?: keyof FieldErrors;
+      keyboardType?: 'default' | 'email-address' | 'numeric';
+      secureTextEntry?: boolean;
+      autoCapitalize?: 'none' | 'sentences';
+    },
+  ) {
+    const err = options.errorKey ? fieldErrors[options.errorKey] : undefined;
+    const isPassword = options.secureTextEntry;
+
+    return (
+      <View style={styles.inputGroup}>
+        <Text style={styles.label}>{label}</Text>
+        <View style={isPassword ? styles.passwordRow : undefined}>
+          <TextInput
+            style={[styles.input, err && styles.inputError, isPassword && styles.passwordInput]}
+            placeholder={options.placeholder}
+            placeholderTextColor={C.placeholder}
+            keyboardType={options.keyboardType ?? 'default'}
+            secureTextEntry={isPassword && !showPassword}
+            autoCapitalize={options.autoCapitalize ?? 'sentences'}
+            value={value}
+            onChangeText={onChangeText}
+          />
+          {isPassword && (
+            <TouchableOpacity
+              style={styles.eyeButton}
+              onPress={() => setShowPassword(!showPassword)}
+            >
+              <Ionicons name={showPassword ? 'eye-off' : 'eye'} size={20} color={C.textMuted} />
+            </TouchableOpacity>
+          )}
+        </View>
+        {err && <Text style={styles.fieldError}>{err}</Text>}
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      <KeyboardAvoidingView
+        style={styles.flex}
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+      >
+        <ScrollView
+          contentContainerStyle={styles.scrollContent}
+          keyboardShouldPersistTaps="handled"
+          showsVerticalScrollIndicator={false}
+        >
+          {/* Header */}
+          <View style={[styles.header, { paddingTop: insets.top + 30 }]}>
+            <View style={styles.iconCircle}>
+              <Ionicons name="person-add" size={32} color={C.white} />
+            </View>
+            <Text style={styles.appName}>セバス・ホー</Text>
+            <Text style={styles.subtitle}>新規アカウント作成</Text>
+          </View>
+
+          {/* Form */}
+          <View style={styles.formCard}>
+            <Text style={styles.formTitle}>サインアップ</Text>
+
+            {apiError ? (
+              <View style={styles.errorBox}>
+                <Ionicons name="alert-circle" size={16} color={C.error} />
+                <Text style={styles.errorText}>{apiError}</Text>
+              </View>
+            ) : null}
+
+            {renderInput('ユーザー名', name, setName, {
+              placeholder: 'お名前を入力',
+              errorKey: 'name',
+            })}
+
+            {renderInput('メールアドレス', email, setEmail, {
+              placeholder: 'example@email.com',
+              errorKey: 'email',
+              keyboardType: 'email-address',
+              autoCapitalize: 'none',
+            })}
+
+            {renderInput('パスワード', password, setPassword, {
+              placeholder: '英数字8文字以上',
+              errorKey: 'password',
+              secureTextEntry: true,
+              autoCapitalize: 'none',
+            })}
+
+            {renderInput('朝の身支度時間（分）', preparationMinutes, setPreparationMinutes, {
+              placeholder: '例: 30',
+              errorKey: 'preparation_minutes',
+              keyboardType: 'numeric',
+            })}
+
+            {renderInput('自宅住所', homeAddress, setHomeAddress, {
+              placeholder: '住所を入力',
+              errorKey: 'home_address',
+            })}
+
+            <TouchableOpacity
+              style={[styles.button, (!allFilled || loading) && styles.buttonDisabled]}
+              onPress={handleRegister}
+              disabled={!allFilled || loading}
+              activeOpacity={0.7}
+            >
+              {loading ? (
+                <ActivityIndicator color={C.white} />
+              ) : (
+                <Text style={styles.buttonText}>サインアップ</Text>
+              )}
+            </TouchableOpacity>
+
+            <TouchableOpacity style={styles.linkButton} onPress={() => router.back()}>
+              <Text style={styles.linkText}>
+                アカウントをお持ちの方は
+                <Text style={styles.linkTextBold}> ログイン</Text>
+              </Text>
+            </TouchableOpacity>
+          </View>
+        </ScrollView>
+      </KeyboardAvoidingView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: C.primary,
+  },
+  flex: {
+    flex: 1,
+  },
+  scrollContent: {
+    flexGrow: 1,
+  },
+
+  // Header
+  header: {
+    alignItems: 'center',
+    paddingBottom: 24,
+    paddingHorizontal: 14,
+  },
+  iconCircle: {
+    width: 72,
+    height: 72,
+    borderRadius: 36,
+    backgroundColor: 'rgba(255,255,255,0.25)',
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginBottom: 14,
+  },
+  appName: {
+    fontSize: 28,
+    fontWeight: '700',
+    color: C.white,
+    marginBottom: 6,
+  },
+  subtitle: {
+    fontSize: 14,
+    fontWeight: '400',
+    color: 'rgba(255,255,255,0.8)',
+  },
+
+  // Form
+  formCard: {
+    flex: 1,
+    backgroundColor: C.white,
+    borderTopLeftRadius: 20,
+    borderTopRightRadius: 20,
+    paddingHorizontal: 24,
+    paddingTop: 28,
+    paddingBottom: 40,
+  },
+  formTitle: {
+    fontSize: 20,
+    fontWeight: '700',
+    color: C.textPrimary,
+    marginBottom: 20,
+  },
+
+  // Error
+  errorBox: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    backgroundColor: '#FEF2F2',
+    borderRadius: 7,
+    padding: 12,
+    marginBottom: 16,
+  },
+  errorText: {
+    flex: 1,
+    fontSize: 13,
+    fontWeight: '500',
+    color: C.error,
+  },
+
+  // Input
+  inputGroup: {
+    marginBottom: 16,
+  },
+  label: {
+    fontSize: 13,
+    fontWeight: '600',
+    color: C.textSecondary,
+    marginBottom: 8,
+  },
+  input: {
+    height: 48,
+    borderWidth: 1,
+    borderColor: C.bg,
+    borderRadius: 7,
+    paddingHorizontal: 14,
+    fontSize: 15,
+    color: C.textPrimary,
+    backgroundColor: C.white,
+  },
+  inputError: {
+    borderColor: C.error,
+  },
+  passwordRow: {
+    position: 'relative',
+  },
+  passwordInput: {
+    paddingRight: 48,
+  },
+  eyeButton: {
+    position: 'absolute',
+    right: 14,
+    top: 14,
+  },
+  fieldError: {
+    fontSize: 12,
+    color: C.error,
+    marginTop: 4,
+  },
+
+  // Button
+  button: {
+    height: 50,
+    backgroundColor: C.primary,
+    borderRadius: 7,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginTop: 8,
+  },
+  buttonDisabled: {
+    opacity: 0.5,
+  },
+  buttonText: {
+    fontSize: 16,
+    fontWeight: '700',
+    color: C.white,
+  },
+
+  // Link
+  linkButton: {
+    alignItems: 'center',
+    marginTop: 20,
+    padding: 8,
+  },
+  linkText: {
+    fontSize: 14,
+    color: C.textSecondary,
+  },
+  linkTextBold: {
+    fontWeight: '700',
+    color: C.primary,
+  },
+});

--- a/frontend/app/schedule/destination-picker.tsx
+++ b/frontend/app/schedule/destination-picker.tsx
@@ -9,7 +9,7 @@ import {
   Platform,
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { useRouter } from 'expo-router';
+import { useRouter, useLocalSearchParams } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
 import {
   APIProvider,
@@ -277,18 +277,31 @@ function MapContent({
 export default function DestinationPickerScreen() {
   const insets = useSafeAreaInsets();
   const router = useRouter();
+  const { returnTo } = useLocalSearchParams<{ returnTo?: string }>();
   const [selected, setSelected] = useState<SelectedPlace | null>(null);
 
   const handleConfirm = () => {
     if (!selected) return;
-    router.navigate({
-      pathname: '/schedule/create',
-      params: {
-        destination_lat: String(selected.lat),
-        destination_lon: String(selected.lng),
-        destination_name: selected.name,
-      },
-    });
+
+    if (returnTo === 'auth/register') {
+      router.navigate({
+        pathname: '/auth/register',
+        params: {
+          home_lat: String(selected.lat),
+          home_lon: String(selected.lng),
+          home_address: selected.name,
+        },
+      });
+    } else {
+      router.navigate({
+        pathname: '/schedule/create',
+        params: {
+          destination_lat: String(selected.lat),
+          destination_lon: String(selected.lng),
+          destination_name: selected.name,
+        },
+      });
+    }
   };
 
   if (!GOOGLE_MAPS_API_KEY) {

--- a/frontend/lib/api-client.ts
+++ b/frontend/lib/api-client.ts
@@ -1,10 +1,14 @@
-const BASE_URL = 'https://fastapi-backend-825512055944.asia-northeast1.run.app/api/v1';
+export const BASE_URL = 'https://fastapi-backend-825512055944.asia-northeast1.run.app/api/v1';
 
 // TODO: ログイン機能実装後はlocalStorageから取得する
 // 現在はテスト用トークンを使用
 // 注意: Cloud RunのCORSが本番では無効のため、ブラウザからのloginリクエストは通らない
 // そのためJSON APIでログインしてトークンをキャッシュする方式を取る
 let cachedToken: string | null = null;
+
+export function setToken(token: string) {
+  cachedToken = token;
+}
 
 async function getToken(): Promise<string> {
   if (cachedToken) return cachedToken;


### PR DESCRIPTION
## Summary
- 画面設計書に基づき、ログイン画面（`/auth/login`）とサインアップ画面（`/auth/register`）を新規実装
- 既存画面のデザイン言語（Primary `#436F9B`、角丸、タイポグラフィ）を踏襲した統一的なUI
- メールフォーマット・パスワード強度・ユーザー名長さ等のフロントバリデーション実装

## 主な変更
- `frontend/app/auth/_layout.tsx` - authグループレイアウト
- `frontend/app/auth/login.tsx` - ログイン画面（メール/パスワード入力、API連携、エラー表示）
- `frontend/app/auth/register.tsx` - サインアップ画面（5項目入力、フィールド単位バリデーション、全入力時のみボタン活性）
- `frontend/app/_layout.tsx` - ルートレイアウトにauthルート追加

## TODO（別PR予定）
- AsyncStorageでのトークン永続化
- 初回起動時の認証状態チェックによるルーティング分岐
- 住所からのジオコーディング（緯度経度算出）

## Test plan
- [ ] `/auth/login` でログイン画面が表示される
- [ ] `/auth/register` でサインアップ画面が表示される
- [ ] ログイン画面 → サインアップリンク → サインアップ画面へ遷移
- [ ] サインアップ画面 → ログインリンク → ログイン画面へ戻る
- [ ] バリデーションエラーが正しく表示される
- [ ] パスワード表示/非表示トグルが動作する

🤖 Generated with [Claude Code](https://claude.com/claude-code)