### PR TITLE
feat: マイページ・ログアウト機能とタブバー見切れ修正

### DIFF
--- a/frontend/app/(tabs)/_layout.tsx
+++ b/frontend/app/(tabs)/_layout.tsx
@@ -16,6 +16,9 @@ export default function TabLayout() {
           borderTopWidth: 1,
           borderTopColor: '#EEF0F1',
           backgroundColor: '#FFFFFF',
+          height: 90,
+          paddingBottom: 28,
+          paddingTop: 8,
         },
         tabBarLabelStyle: {
           fontSize: 12.25,

--- a/frontend/app/(tabs)/mypage.tsx
+++ b/frontend/app/(tabs)/mypage.tsx
@@ -1,10 +1,177 @@
-import React from 'react';
-import { StyleSheet, Text, View } from 'react-native';
+import React, { useEffect, useState } from 'react';
+import {
+  Alert,
+  ActivityIndicator,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useRouter } from 'expo-router';
+import { Ionicons, MaterialCommunityIcons } from '@expo/vector-icons';
+import { apiGet, BASE_URL, clearToken } from '@/lib/api-client';
+
+const C = {
+  primary: '#436F9B',
+  white: '#FFFFFF',
+  textPrimary: '#1F2528',
+  textSecondary: '#63747E',
+  textMuted: '#B5BFC5',
+  bg: '#EEF0F1',
+  danger: '#D94040',
+};
+
+type UserProfile = {
+  id: number;
+  email: string;
+  name: string;
+  created_at: string;
+};
+
+type UserSettings = {
+  home_address: string;
+  preparation_minutes: number;
+  reminder_minutes_before: number;
+};
 
 export default function MyPageScreen() {
+  const insets = useSafeAreaInsets();
+  const router = useRouter();
+  const [profile, setProfile] = useState<UserProfile | null>(null);
+  const [settings, setSettings] = useState<UserSettings | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [loggingOut, setLoggingOut] = useState(false);
+
+  useEffect(() => {
+    async function fetchData() {
+      try {
+        const [p, s] = await Promise.all([
+          apiGet<UserProfile>('/users/me'),
+          apiGet<UserSettings>('/users/me/settings'),
+        ]);
+        setProfile(p);
+        setSettings(s);
+      } catch {
+        // トークンがない場合などはエラーを無視して空表示
+      } finally {
+        setLoading(false);
+      }
+    }
+    fetchData();
+  }, []);
+
+  async function handleLogout() {
+    Alert.alert('ログアウト', 'ログアウトしますか？', [
+      { text: 'キャンセル', style: 'cancel' },
+      {
+        text: 'ログアウト',
+        style: 'destructive',
+        onPress: async () => {
+          setLoggingOut(true);
+          try {
+            await fetch(`${BASE_URL}/auth/logout`, {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+            });
+          } catch {
+            // ログアウトAPI失敗してもローカルトークンはクリアする
+          }
+          clearToken();
+          router.replace('/auth/login');
+        },
+      },
+    ]);
+  }
+
+  function renderInfoRow(icon: React.ReactNode, label: string, value: string) {
+    return (
+      <View style={styles.infoRow}>
+        <View style={styles.infoIcon}>{icon}</View>
+        <View style={styles.infoContent}>
+          <Text style={styles.infoLabel}>{label}</Text>
+          <Text style={styles.infoValue}>{value}</Text>
+        </View>
+      </View>
+    );
+  }
+
+  if (loading) {
+    return (
+      <View style={[styles.container, styles.center]}>
+        <ActivityIndicator size="large" color={C.primary} />
+      </View>
+    );
+  }
+
   return (
     <View style={styles.container}>
-      <Text style={styles.text}>マイページ</Text>
+      <ScrollView
+        contentContainerStyle={[styles.scrollContent, { paddingBottom: insets.bottom + 100 }]}
+        showsVerticalScrollIndicator={false}
+      >
+        {/* Header */}
+        <View style={[styles.header, { paddingTop: insets.top + 20 }]}>
+          <View style={styles.avatarCircle}>
+            <Ionicons name="person" size={36} color={C.white} />
+          </View>
+          <Text style={styles.userName}>{profile?.name ?? '---'}</Text>
+          <Text style={styles.userEmail}>{profile?.email ?? '---'}</Text>
+        </View>
+
+        {/* Settings card */}
+        <View style={styles.card}>
+          <Text style={styles.cardTitle}>アカウント情報</Text>
+
+          {renderInfoRow(
+            <Ionicons name="mail-outline" size={20} color={C.primary} />,
+            'メールアドレス',
+            profile?.email ?? '---'
+          )}
+
+          <View style={styles.divider} />
+
+          {renderInfoRow(
+            <MaterialCommunityIcons name="clock-outline" size={20} color={C.primary} />,
+            '朝の身支度時間',
+            settings ? `${settings.preparation_minutes}分` : '---'
+          )}
+
+          <View style={styles.divider} />
+
+          {renderInfoRow(
+            <Ionicons name="location-outline" size={20} color={C.primary} />,
+            '自宅住所',
+            settings?.home_address ?? '---'
+          )}
+
+          <View style={styles.divider} />
+
+          {renderInfoRow(
+            <Ionicons name="notifications-outline" size={20} color={C.primary} />,
+            'リマインダー',
+            settings ? `${settings.reminder_minutes_before}分前` : '---'
+          )}
+        </View>
+
+        {/* Logout */}
+        <TouchableOpacity
+          style={styles.logoutButton}
+          onPress={handleLogout}
+          disabled={loggingOut}
+          activeOpacity={0.7}
+        >
+          {loggingOut ? (
+            <ActivityIndicator color={C.danger} />
+          ) : (
+            <>
+              <Ionicons name="log-out-outline" size={20} color={C.danger} />
+              <Text style={styles.logoutText}>ログアウト</Text>
+            </>
+          )}
+        </TouchableOpacity>
+      </ScrollView>
     </View>
   );
 }
@@ -12,13 +179,116 @@ export default function MyPageScreen() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
+    backgroundColor: C.bg,
+  },
+  center: {
     alignItems: 'center',
     justifyContent: 'center',
-    backgroundColor: '#FFFFFF',
   },
-  text: {
-    fontSize: 17.5,
+  scrollContent: {
+    flexGrow: 1,
+  },
+
+  // Header
+  header: {
+    backgroundColor: C.primary,
+    alignItems: 'center',
+    paddingBottom: 28,
+    paddingHorizontal: 14,
+  },
+  avatarCircle: {
+    width: 72,
+    height: 72,
+    borderRadius: 36,
+    backgroundColor: 'rgba(255,255,255,0.25)',
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginBottom: 12,
+  },
+  userName: {
+    fontSize: 20,
     fontWeight: '700',
-    color: '#1F2528',
+    color: C.white,
+    marginBottom: 4,
+  },
+  userEmail: {
+    fontSize: 13,
+    fontWeight: '400',
+    color: 'rgba(255,255,255,0.7)',
+  },
+
+  // Card
+  card: {
+    backgroundColor: C.white,
+    marginHorizontal: 14,
+    marginTop: -14,
+    borderRadius: 14,
+    padding: 20,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.08,
+    shadowRadius: 4,
+    elevation: 2,
+  },
+  cardTitle: {
+    fontSize: 14,
+    fontWeight: '700',
+    color: C.textPrimary,
+    marginBottom: 16,
+  },
+
+  // Info row
+  infoRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+    paddingVertical: 8,
+  },
+  infoIcon: {
+    width: 36,
+    height: 36,
+    borderRadius: 8,
+    backgroundColor: C.bg,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  infoContent: {
+    flex: 1,
+  },
+  infoLabel: {
+    fontSize: 12,
+    fontWeight: '500',
+    color: C.textSecondary,
+    marginBottom: 2,
+  },
+  infoValue: {
+    fontSize: 15,
+    fontWeight: '500',
+    color: C.textPrimary,
+  },
+  divider: {
+    height: 1,
+    backgroundColor: C.bg,
+    marginVertical: 4,
+  },
+
+  // Logout
+  logoutButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 8,
+    marginHorizontal: 14,
+    marginTop: 24,
+    backgroundColor: C.white,
+    borderRadius: 7,
+    borderWidth: 1,
+    borderColor: C.danger,
+    paddingVertical: 14,
+  },
+  logoutText: {
+    fontSize: 15,
+    fontWeight: '700',
+    color: C.danger,
   },
 });

--- a/frontend/app/(tabs)/mypage.tsx
+++ b/frontend/app/(tabs)/mypage.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from 'react';
 import {
-  Alert,
   ActivityIndicator,
   ScrollView,
   StyleSheet,
@@ -63,26 +62,20 @@ export default function MyPageScreen() {
   }, []);
 
   async function handleLogout() {
-    Alert.alert('ログアウト', 'ログアウトしますか？', [
-      { text: 'キャンセル', style: 'cancel' },
-      {
-        text: 'ログアウト',
-        style: 'destructive',
-        onPress: async () => {
-          setLoggingOut(true);
-          try {
-            await fetch(`${BASE_URL}/auth/logout`, {
-              method: 'POST',
-              headers: { 'Content-Type': 'application/json' },
-            });
-          } catch {
-            // ログアウトAPI失敗してもローカルトークンはクリアする
-          }
-          clearToken();
-          router.replace('/auth/login');
-        },
-      },
-    ]);
+    const confirmed = window?.confirm?.('ログアウトしますか？') ?? true;
+    if (!confirmed) return;
+
+    setLoggingOut(true);
+    try {
+      await fetch(`${BASE_URL}/auth/logout`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+      });
+    } catch {
+      // ログアウトAPI失敗してもローカルトークンはクリアする
+    }
+    clearToken();
+    router.replace('/auth/login');
   }
 
   function renderInfoRow(icon: React.ReactNode, label: string, value: string) {

--- a/frontend/lib/api-client.ts
+++ b/frontend/lib/api-client.ts
@@ -10,6 +10,10 @@ export function setToken(token: string) {
   cachedToken = token;
 }
 
+export function clearToken() {
+  cachedToken = null;
+}
+
 async function getToken(): Promise<string> {
   if (cachedToken) return cachedToken;
 


### PR DESCRIPTION
## Summary
- マイページ画面にユーザー情報表示（メール、身支度時間、住所、リマインダー）とログアウト機能を実装
- タブバーのラベルが画面下端で見切れる問題を修正
- ログアウト後にログイン画面へ正しく遷移するよう修正

## 主な変更
- `frontend/app/(tabs)/mypage.tsx` - マイページ画面実装（API連携、ログアウト）
- `frontend/app/(tabs)/_layout.tsx` - タブバーのheight/padding調整
- `frontend/lib/api-client.ts` - `clearToken()` 関数追加

## Test plan
- [ ] マイページタブでユーザー情報が表示される
- [ ] ログアウトボタン押下 → 確認ダイアログ → ログイン画面へ遷移
- [ ] タブバーのラベルがモバイル表示で見切れない

🤖 Generated with [Claude Code](https://claude.com/claude-code)