### PR TITLE
fix: transit検索結果から徒歩のみルートをフィルタ除外

### DIFF
--- a/backend/app/services/otp2_client.py
+++ b/backend/app/services/otp2_client.py
@@ -202,6 +202,12 @@ async def search_routes(
         raise AppError("OTP_UNAVAILABLE", "Route planning service is unavailable", 503) from None
 
     itineraries = _parse_itineraries(data)
+
+    # transit検索時、徒歩のみのitineraryを除外する
+    # OTP2はtransitモードでも代替として徒歩ルートを返すことがある
+    if travel_mode == "transit":
+        itineraries = [it for it in itineraries if any(leg["mode"] != "WALK" for leg in it["legs"])]
+
     if not itineraries:
         raise AppError("ROUTE_NOT_FOUND", "No routes found for the specified conditions", 404)
 


### PR DESCRIPTION
## Summary
- OTP2はtransitモードでも代替として徒歩のみルート(WALK only)を返すことがある
- `search_routes()`で`travel_mode=="transit"`の場合、公共交通機関のlegを1つも含まないitineraryを除外するフィルタを追加

## 再現していた事象
電車タブの検索結果一覧の先頭に、徒歩56分(乗換0回)のような徒歩のみルートが表示されていた

## Test plan
- [ ] `/api/v1/routes/search` に `travel_mode=transit` でリクエスト → WALK onlyのitineraryが含まれないこと
- [ ] 電車タブで公共交通機関を含むルートのみ表示されること

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)