### PR TITLE
fix: ルート検索結果の表示バグ修正

### DIFF
--- a/backend/app/services/otp2_client.py
+++ b/backend/app/services/otp2_client.py
@@ -203,10 +203,20 @@ async def search_routes(
 
     itineraries = _parse_itineraries(data)
 
-    # transit検索時、徒歩のみのitineraryを除外する
-    # OTP2はtransitモードでも代替として徒歩ルートを返すことがある
-    if travel_mode == "transit":
-        itineraries = [it for it in itineraries if any(leg["mode"] != "WALK" for leg in it["legs"])]
+    # OTP2は指定モード以外のlegを含むルートを代替として返すことがある
+    # 各モードで許可されるleg modeのみ含むitineraryにフィルタする
+    _expected_modes: dict[str, set[str]] = {
+        "transit": {"WALK", "RAIL", "SUBWAY", "BUS"},
+        "walking": {"WALK"},
+        "cycling": {"BICYCLE", "WALK"},
+        "driving": {"CAR", "WALK"},
+    }
+    allowed = _expected_modes.get(travel_mode)
+    if allowed:
+        itineraries = [it for it in itineraries if all(leg["mode"] in allowed for leg in it["legs"])]
+        # transit: 徒歩のみルートも除外
+        if travel_mode == "transit":
+            itineraries = [it for it in itineraries if any(leg["mode"] != "WALK" for leg in it["legs"])]
 
     if not itineraries:
         raise AppError("ROUTE_NOT_FOUND", "No routes found for the specified conditions", 404)

--- a/frontend/components/route-results.tsx
+++ b/frontend/components/route-results.tsx
@@ -202,8 +202,7 @@ function ItineraryCard({ itinerary }: { itinerary: ItineraryResponse }) {
 
         {itinerary.legs.map((leg, legIndex) => {
           // 最後のWALK legは目的地バッジ側で表示するのでスキップ
-          const isLastWalkLeg =
-            legIndex === itinerary.legs.length - 1 && leg.mode === 'WALK';
+          const isLastWalkLeg = legIndex === itinerary.legs.length - 1 && leg.mode === 'WALK';
           return (
             <React.Fragment key={legIndex}>
               {/* Connector (最後のWALK legは除く) */}

--- a/frontend/components/route-results.tsx
+++ b/frontend/components/route-results.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useCallback } from 'react';
+import React, { useEffect, useState } from 'react';
 import { ActivityIndicator, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { Ionicons, MaterialCommunityIcons } from '@expo/vector-icons';
 import { apiPost } from '../lib/api-client';
@@ -75,32 +75,41 @@ export default function RouteResults({
   const [data, setData] = useState<RouteSearchResponse | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-
-  const fetchRoutes = useCallback(async () => {
-    setLoading(true);
-    setError(null);
-
-    const body: RouteSearchRequest = {
-      destination_lat: destinationLat,
-      destination_lon: destinationLon,
-      travel_mode: activeMode,
-      arrival_time: arrivalTime,
-    };
-
-    try {
-      const result = await apiPost<RouteSearchResponse>('/routes/search', body);
-      setData(result);
-    } catch (e: any) {
-      setError(e.message || 'ルートの取得に失敗しました');
-      setData(null);
-    } finally {
-      setLoading(false);
-    }
-  }, [destinationLat, destinationLon, arrivalTime, activeMode]);
+  const [retryCount, setRetryCount] = useState(0);
 
   useEffect(() => {
+    let cancelled = false;
+
+    async function fetchRoutes() {
+      setLoading(true);
+      setError(null);
+      setData(null);
+
+      const body: RouteSearchRequest = {
+        destination_lat: destinationLat,
+        destination_lon: destinationLon,
+        travel_mode: activeMode,
+        arrival_time: arrivalTime,
+      };
+
+      try {
+        const result = await apiPost<RouteSearchResponse>('/routes/search', body);
+        if (!cancelled) setData(result);
+      } catch (e: any) {
+        if (!cancelled) {
+          setError(e.message || 'ルートの取得に失敗しました');
+          setData(null);
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+
     fetchRoutes();
-  }, [fetchRoutes]);
+    return () => {
+      cancelled = true;
+    };
+  }, [destinationLat, destinationLon, arrivalTime, activeMode, retryCount]);
 
   return (
     <View style={styles.container}>
@@ -140,7 +149,7 @@ export default function RouteResults({
         <View style={styles.centerContainer}>
           <Ionicons name="alert-circle-outline" size={32} color={C.textMuted} />
           <Text style={styles.errorText}>{error}</Text>
-          <TouchableOpacity style={styles.retryButton} onPress={fetchRoutes}>
+          <TouchableOpacity style={styles.retryButton} onPress={() => setRetryCount(c => c + 1)}>
             <Text style={styles.retryText}>再試行</Text>
           </TouchableOpacity>
         </View>

--- a/frontend/components/route-results.tsx
+++ b/frontend/components/route-results.tsx
@@ -200,49 +200,56 @@ function ItineraryCard({ itinerary }: { itinerary: ItineraryResponse }) {
           </View>
         </View>
 
-        {itinerary.legs.map((leg, legIndex) => (
-          <React.Fragment key={legIndex}>
-            {/* Connector */}
-            <View style={styles.connector}>
-              {leg.mode === 'WALK' ? (
-                <View style={styles.connectorContent}>
-                  <MaterialCommunityIcons name="walk" size={14} color={C.textSecondary} />
-                  <Text style={styles.connectorText}>{leg.duration_minutes}分</Text>
-                </View>
-              ) : (
-                <View style={styles.connectorContent}>
-                  {leg.route_short_name && (
-                    <View
-                      style={[
-                        styles.lineBadge,
-                        {
-                          borderColor: getLineColor(leg.route_short_name),
-                        },
-                      ]}
-                    >
-                      <Text
-                        style={[
-                          styles.lineBadgeText,
-                          { color: getLineColor(leg.route_short_name) },
-                        ]}
-                      >
-                        {leg.route_short_name}
-                      </Text>
+        {itinerary.legs.map((leg, legIndex) => {
+          // 最後のWALK legは目的地バッジ側で表示するのでスキップ
+          const isLastWalkLeg =
+            legIndex === itinerary.legs.length - 1 && leg.mode === 'WALK';
+          return (
+            <React.Fragment key={legIndex}>
+              {/* Connector (最後のWALK legは除く) */}
+              {!isLastWalkLeg && (
+                <View style={styles.connector}>
+                  {leg.mode === 'WALK' ? (
+                    <View style={styles.connectorContent}>
+                      <MaterialCommunityIcons name="walk" size={14} color={C.textSecondary} />
+                      <Text style={styles.connectorText}>{leg.duration_minutes}分</Text>
+                    </View>
+                  ) : (
+                    <View style={styles.connectorContent}>
+                      {leg.route_short_name && (
+                        <View
+                          style={[
+                            styles.lineBadge,
+                            {
+                              borderColor: getLineColor(leg.route_short_name),
+                            },
+                          ]}
+                        >
+                          <Text
+                            style={[
+                              styles.lineBadgeText,
+                              { color: getLineColor(leg.route_short_name) },
+                            ]}
+                          >
+                            {leg.route_short_name}
+                          </Text>
+                        </View>
+                      )}
+                      <Text style={styles.connectorText}>{leg.duration_minutes}分</Text>
                     </View>
                   )}
-                  <Text style={styles.connectorText}>{leg.duration_minutes}分</Text>
                 </View>
               )}
-            </View>
 
-            {/* Station */}
-            {legIndex < itinerary.legs.length - 1 && (
-              <View style={styles.timelineStep}>
-                <Text style={styles.stationName}>{leg.to_name}</Text>
-              </View>
-            )}
-          </React.Fragment>
-        ))}
+              {/* Station */}
+              {legIndex < itinerary.legs.length - 1 && (
+                <View style={styles.timelineStep}>
+                  <Text style={styles.stationName}>{leg.to_name}</Text>
+                </View>
+              )}
+            </React.Fragment>
+          );
+        })}
 
         {/* Destination badge */}
         <View style={styles.timelineStep}>


### PR DESCRIPTION
## Summary
- 電車タブに徒歩のみルートが混入する問題を修正（バックエンド全モードでleg modeフィルタリング追加）
- 車タブに電車ルートが混入する問題を修正（driving/walking/cyclingでも許可されないleg modeを除外）
- 電車タブで目的地手前に歩きアイコンが2回表示される問題を修正（最後のWALK legの重複描画を解消）
- タブ切替時にAPIレスポンスの競合で別モードの結果が表示される問題を修正（cancelledフラグによるrace condition対策）

## Test plan
- [ ] 電車タブ: 公共交通機関を含むルートのみ表示、歩きアイコンは目的地手前に1回のみ
- [ ] 車タブ: CAR+WALKのみのルートが表示、電車ルートが混入しないこと
- [ ] 走る人タブ: WALKのみのルートが表示されること
- [ ] タブを素早く切り替えても正しいモードの結果が表示されること

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)