### PR TITLE
fix: 車・徒歩ルートをGoogle Routes API v2に切り替え

### DIFF
--- a/backend/app/services/google_routes_client.py
+++ b/backend/app/services/google_routes_client.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 import httpx
 
@@ -84,10 +84,15 @@ async def search_routes_google(
         logger.exception("Google Routes API connection error")
         raise AppError("GOOGLE_ROUTES_ERROR", "Google Routes API is unavailable", 503) from None
 
-    return _parse_response(data, travel_mode)
+    return _parse_response(data, travel_mode, arrival_time=arrival_time, departure_time=departure_time)
 
 
-def _parse_response(data: dict, travel_mode: str) -> list[dict]:
+def _parse_response(
+    data: dict,
+    travel_mode: str,
+    arrival_time: str | None = None,
+    departure_time: str | None = None,
+) -> list[dict]:
     """Google Routes API v2 レスポンスを OTP2 互換の itinerary 形式に変換."""
     routes = data.get("routes", [])
     if not routes:
@@ -98,10 +103,21 @@ def _parse_response(data: dict, travel_mode: str) -> list[dict]:
         duration_str = route.get("duration", "0s")
         duration_seconds = _parse_duration(duration_str)
         duration_minutes = max(1, int(duration_seconds / 60))
+        delta = timedelta(seconds=duration_seconds)
 
-        now = datetime.now(UTC)
-        departure_time = now.isoformat()
-        arrival_time = now.isoformat()
+        # departure_time / arrival_time をリクエストパラメータと duration から計算
+        if departure_time:
+            dep = datetime.fromisoformat(departure_time)
+            arr = dep + delta
+        elif arrival_time:
+            arr = datetime.fromisoformat(arrival_time)
+            dep = arr - delta
+        else:
+            dep = datetime.now(UTC)
+            arr = dep + delta
+
+        dep_str = dep.isoformat()
+        arr_str = arr.isoformat()
 
         mode = "CAR" if travel_mode == "driving" else "WALK"
 
@@ -111,21 +127,35 @@ def _parse_response(data: dict, travel_mode: str) -> list[dict]:
             leg_duration_seconds = _parse_duration(leg_duration_str)
             leg_duration_minutes = max(1, int(leg_duration_seconds / 60))
 
+            # leg の from_name / to_name を座標から生成
+            start_loc = leg.get("startLocation", {}).get("latLng", {})
+            end_loc = leg.get("endLocation", {}).get("latLng", {})
+            from_name = (
+                f"{start_loc['latitude']:.4f}, {start_loc['longitude']:.4f}"
+                if start_loc.get("latitude") is not None
+                else "出発地"
+            )
+            to_name = (
+                f"{end_loc['latitude']:.4f}, {end_loc['longitude']:.4f}"
+                if end_loc.get("latitude") is not None
+                else "目的地"
+            )
+
             legs.append(
                 {
                     "mode": mode,
-                    "from_name": "出発地",
-                    "to_name": "目的地",
-                    "departure_time": departure_time,
-                    "arrival_time": arrival_time,
+                    "from_name": from_name,
+                    "to_name": to_name,
+                    "departure_time": dep_str,
+                    "arrival_time": arr_str,
                     "duration_minutes": leg_duration_minutes,
                 }
             )
 
         itineraries.append(
             {
-                "departure_time": departure_time,
-                "arrival_time": arrival_time,
+                "departure_time": dep_str,
+                "arrival_time": arr_str,
                 "duration_minutes": duration_minutes,
                 "legs": legs,
             }

--- a/backend/app/services/google_routes_client.py
+++ b/backend/app/services/google_routes_client.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+
+import httpx
+
+from app.config import settings
+from app.exceptions import AppError
+
+logger = logging.getLogger(__name__)
+
+ROUTES_API_URL = "https://routes.googleapis.com/directions/v2:computeRoutes"
+ROUTES_API_SCOPE = "https://www.googleapis.com/auth/cloud-platform"
+
+_TRAVEL_MODE_MAP = {
+    "driving": "DRIVE",
+    "walking": "WALK",
+}
+
+
+def _get_access_token() -> str:
+    """Google Cloud のアクセストークンを取得する（ADC / サービスアカウント）."""
+    import google.auth
+    import google.auth.transport.requests
+
+    credentials, _ = google.auth.default(scopes=[ROUTES_API_SCOPE])
+    credentials.refresh(google.auth.transport.requests.Request())
+    return credentials.token
+
+
+async def search_routes_google(
+    origin_lat: float,
+    origin_lon: float,
+    dest_lat: float,
+    dest_lon: float,
+    travel_mode: str,
+    arrival_time: str | None = None,
+    departure_time: str | None = None,
+) -> list[dict]:
+    """Google Routes API v2 で車・徒歩の経路検索を行う."""
+    google_mode = _TRAVEL_MODE_MAP.get(travel_mode)
+    if not google_mode:
+        raise AppError("INVALID_MODE", f"Unsupported travel mode for Google Routes: {travel_mode}", 400)
+
+    body: dict = {
+        "origin": {"location": {"latLng": {"latitude": origin_lat, "longitude": origin_lon}}},
+        "destination": {"location": {"latLng": {"latitude": dest_lat, "longitude": dest_lon}}},
+        "travelMode": google_mode,
+        "languageCode": "ja",
+    }
+
+    if departure_time:
+        body["departureTime"] = departure_time
+    elif arrival_time and google_mode == "DRIVE":
+        # arrivalTime は DRIVE モードのみ対応
+        body["arrivalTime"] = arrival_time
+
+    try:
+        token = _get_access_token()
+    except Exception:
+        logger.exception("Failed to get Google Cloud access token")
+        raise AppError("GOOGLE_ROUTES_ERROR", "Failed to authenticate with Google Cloud", 503) from None
+
+    headers = {
+        "Content-Type": "application/json",
+        "Authorization": f"Bearer {token}",
+        "X-Goog-User-Project": settings.GCP_PROJECT_ID,
+        "X-Goog-FieldMask": "routes.duration,routes.legs.duration,routes.legs.startLocation,routes.legs.endLocation",
+    }
+
+    try:
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(ROUTES_API_URL, json=body, headers=headers, timeout=30.0)
+
+            if resp.status_code != 200:
+                logger.warning("Google Routes API returned status %d: %s", resp.status_code, resp.text[:200])
+                raise AppError("GOOGLE_ROUTES_ERROR", "Google Routes API request failed", 503)
+
+            data = resp.json()
+    except AppError:
+        raise
+    except httpx.HTTPError:
+        logger.exception("Google Routes API connection error")
+        raise AppError("GOOGLE_ROUTES_ERROR", "Google Routes API is unavailable", 503) from None
+
+    return _parse_response(data, travel_mode)
+
+
+def _parse_response(data: dict, travel_mode: str) -> list[dict]:
+    """Google Routes API v2 レスポンスを OTP2 互換の itinerary 形式に変換."""
+    routes = data.get("routes", [])
+    if not routes:
+        raise AppError("ROUTE_NOT_FOUND", "No routes found for the specified conditions", 404)
+
+    itineraries = []
+    for route in routes:
+        duration_str = route.get("duration", "0s")
+        duration_seconds = _parse_duration(duration_str)
+        duration_minutes = max(1, int(duration_seconds / 60))
+
+        now = datetime.now(UTC)
+        departure_time = now.isoformat()
+        arrival_time = now.isoformat()
+
+        mode = "CAR" if travel_mode == "driving" else "WALK"
+
+        legs = []
+        for leg in route.get("legs", []):
+            leg_duration_str = leg.get("duration", "0s")
+            leg_duration_seconds = _parse_duration(leg_duration_str)
+            leg_duration_minutes = max(1, int(leg_duration_seconds / 60))
+
+            legs.append(
+                {
+                    "mode": mode,
+                    "from_name": "出発地",
+                    "to_name": "目的地",
+                    "departure_time": departure_time,
+                    "arrival_time": arrival_time,
+                    "duration_minutes": leg_duration_minutes,
+                }
+            )
+
+        itineraries.append(
+            {
+                "departure_time": departure_time,
+                "arrival_time": arrival_time,
+                "duration_minutes": duration_minutes,
+                "legs": legs,
+            }
+        )
+
+    return itineraries
+
+
+def _parse_duration(duration_str: str) -> int:
+    """Google の duration 文字列 (例: '845s') を秒数に変換."""
+    if duration_str.endswith("s"):
+        try:
+            return int(float(duration_str[:-1]))
+        except ValueError:
+            return 0
+    return 0

--- a/backend/app/services/otp2_client.py
+++ b/backend/app/services/otp2_client.py
@@ -164,7 +164,23 @@ async def search_routes(
     arrival_time: str | None = None,
     departure_time: str | None = None,
 ) -> list[dict]:
-    """OTP2 に経路検索リクエストを送信し、itineraries を返す."""
+    """経路検索リクエストを送信し、itineraries を返す.
+
+    driving/walking は Google Routes API v2、transit/cycling は OTP2 を使用。
+    """
+    if travel_mode in ("driving", "walking"):
+        from app.services.google_routes_client import search_routes_google
+
+        return await search_routes_google(
+            origin_lat,
+            origin_lon,
+            dest_lat,
+            dest_lon,
+            travel_mode,
+            arrival_time=arrival_time,
+            departure_time=departure_time,
+        )
+
     query = _build_query(
         origin_lat,
         origin_lon,

--- a/backend/tests/test_google_routes_client.py
+++ b/backend/tests/test_google_routes_client.py
@@ -1,0 +1,137 @@
+"""Google Routes API v2 クライアントのテスト."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.services.google_routes_client import _parse_duration, _parse_response, search_routes_google
+
+
+@pytest.fixture(autouse=True)
+async def setup_db():
+    """DB 接続不要なテストのため conftest の setup_db を上書き."""
+    yield
+
+
+class TestParseDuration:
+    def test_normal(self):
+        assert _parse_duration("845s") == 845
+
+    def test_zero(self):
+        assert _parse_duration("0s") == 0
+
+    def test_float(self):
+        assert _parse_duration("123.4s") == 123
+
+    def test_invalid(self):
+        assert _parse_duration("invalid") == 0
+
+    def test_empty(self):
+        assert _parse_duration("") == 0
+
+
+class TestParseResponse:
+    def test_single_route(self):
+        data = {
+            "routes": [
+                {
+                    "duration": "600s",
+                    "legs": [
+                        {
+                            "duration": "600s",
+                            "startLocation": {"latLng": {"latitude": 35.64, "longitude": 139.67}},
+                            "endLocation": {"latLng": {"latitude": 35.65, "longitude": 139.70}},
+                        }
+                    ],
+                }
+            ]
+        }
+        result = _parse_response(data, "driving")
+        assert len(result) == 1
+        assert result[0]["duration_minutes"] == 10
+        assert result[0]["legs"][0]["mode"] == "CAR"
+        assert result[0]["legs"][0]["duration_minutes"] == 10
+
+    def test_walking_mode(self):
+        data = {
+            "routes": [
+                {
+                    "duration": "900s",
+                    "legs": [{"duration": "900s"}],
+                }
+            ]
+        }
+        result = _parse_response(data, "walking")
+        assert result[0]["legs"][0]["mode"] == "WALK"
+        assert result[0]["duration_minutes"] == 15
+
+    def test_minimum_duration(self):
+        data = {
+            "routes": [
+                {
+                    "duration": "20s",
+                    "legs": [{"duration": "20s"}],
+                }
+            ]
+        }
+        result = _parse_response(data, "driving")
+        assert result[0]["duration_minutes"] == 1
+
+    def test_no_routes(self):
+        from app.exceptions import AppError
+
+        with pytest.raises(AppError):
+            _parse_response({"routes": []}, "driving")
+
+    def test_empty_response(self):
+        from app.exceptions import AppError
+
+        with pytest.raises(AppError):
+            _parse_response({}, "driving")
+
+
+@pytest.mark.asyncio
+class TestSearchRoutesGoogle:
+    @patch("app.services.google_routes_client._get_access_token", return_value="fake-token")
+    @patch("app.services.google_routes_client.settings")
+    @patch("app.services.google_routes_client.httpx.AsyncClient")
+    async def test_success(self, mock_client_cls, mock_settings, mock_token):
+        mock_settings.GCP_PROJECT_ID = "test-project"
+
+        response_data = {
+            "routes": [
+                {
+                    "duration": "600s",
+                    "legs": [{"duration": "600s"}],
+                }
+            ]
+        }
+
+        mock_response = AsyncMock()
+        mock_response.status_code = 200
+        # json() is a sync method on httpx.Response, not async
+        mock_response.json = lambda: response_data
+
+        mock_client = AsyncMock()
+        mock_client.post.return_value = mock_response
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client_cls.return_value = mock_client
+
+        result = await search_routes_google(35.64, 139.67, 35.65, 139.70, "driving")
+        assert len(result) == 1
+        assert result[0]["duration_minutes"] == 10
+
+    @patch("app.services.google_routes_client._get_access_token", side_effect=Exception("No credentials"))
+    async def test_adc_auth_failure(self, mock_token):
+        """ADC認証失敗時はエラー."""
+        from app.exceptions import AppError
+
+        with pytest.raises(AppError, match="GOOGLE_ROUTES_ERROR"):
+            await search_routes_google(35.64, 139.67, 35.65, 139.70, "driving")
+
+    async def test_invalid_mode(self):
+        from app.exceptions import AppError
+
+        with pytest.raises(AppError, match="Unsupported"):
+            await search_routes_google(35.64, 139.67, 35.65, 139.70, "transit")

--- a/backend/tests/test_google_routes_client.py
+++ b/backend/tests/test_google_routes_client.py
@@ -52,6 +52,49 @@ class TestParseResponse:
         assert result[0]["legs"][0]["mode"] == "CAR"
         assert result[0]["legs"][0]["duration_minutes"] == 10
 
+    def test_times_from_departure(self):
+        """departure_time 指定時は duration から arrival_time を計算."""
+        data = {"routes": [{"duration": "600s", "legs": [{"duration": "600s"}]}]}
+        result = _parse_response(data, "driving", departure_time="2026-03-20T10:00:00+09:00")
+        assert result[0]["departure_time"] == "2026-03-20T10:00:00+09:00"
+        assert result[0]["arrival_time"] == "2026-03-20T10:10:00+09:00"
+        assert result[0]["legs"][0]["departure_time"] == "2026-03-20T10:00:00+09:00"
+        assert result[0]["legs"][0]["arrival_time"] == "2026-03-20T10:10:00+09:00"
+
+    def test_times_from_arrival(self):
+        """arrival_time 指定時は duration から departure_time を逆算."""
+        data = {"routes": [{"duration": "900s", "legs": [{"duration": "900s"}]}]}
+        result = _parse_response(data, "walking", arrival_time="2026-03-20T10:00:00+09:00")
+        assert result[0]["arrival_time"] == "2026-03-20T10:00:00+09:00"
+        assert result[0]["departure_time"] == "2026-03-20T09:45:00+09:00"
+
+    def test_from_to_names_from_coordinates(self):
+        """startLocation/endLocation から from_name/to_name を生成."""
+        data = {
+            "routes": [
+                {
+                    "duration": "600s",
+                    "legs": [
+                        {
+                            "duration": "600s",
+                            "startLocation": {"latLng": {"latitude": 35.6436, "longitude": 139.6699}},
+                            "endLocation": {"latLng": {"latitude": 35.6547, "longitude": 139.6977}},
+                        }
+                    ],
+                }
+            ]
+        }
+        result = _parse_response(data, "driving")
+        assert result[0]["legs"][0]["from_name"] == "35.6436, 139.6699"
+        assert result[0]["legs"][0]["to_name"] == "35.6547, 139.6977"
+
+    def test_from_to_names_fallback(self):
+        """座標がない場合は出発地/目的地にフォールバック."""
+        data = {"routes": [{"duration": "600s", "legs": [{"duration": "600s"}]}]}
+        result = _parse_response(data, "driving")
+        assert result[0]["legs"][0]["from_name"] == "出発地"
+        assert result[0]["legs"][0]["to_name"] == "目的地"
+
     def test_walking_mode(self):
         data = {
             "routes": [


### PR DESCRIPTION
## Summary
- OTP2の車ルーティングが非現実的に短い所要時間を返す問題を修正（例: 三軒茶屋→ロースタリー 4分→12分）
- driving/walking を Google Routes API v2（ADC認証）に切り替え
- transit/cycling は引き続きOTP2を使用

## 根本原因
OTP2は公共交通向けエンジンで、車ルートではOSMのmaxspeedタグに基づく理論速度で計算するため、信号・渋滞・右左折遅延が考慮されない。`router-config.json`にも車速度の設定なし。

## 変更内容
- `backend/app/services/google_routes_client.py` — 新規: Google Routes API v2 クライアント（ADC認証）
- `backend/app/services/otp2_client.py` — driving/walking時にGoogle Routesへ分岐
- `backend/tests/test_google_routes_client.py` — ユニットテスト13件

## 前提条件
- GCPプロジェクトで Routes API が有効化済み
- Cloud Runのサービスアカウントに Routes API の呼び出し権限が必要

## Test plan
- [x] ユニットテスト13件パス
- [x] E2E: `POST /api/v1/routes/search` (driving) — 三軒茶屋→ロースタリー **12分**（修正前: 4分）
- [x] E2E: `POST /api/v1/routes/search` (walking) — 同区間 **42分**
- [x] ruff check / ruff format パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)