### PR TITLE
fix: ログアウト後のログイン画面遷移を修正

### DIFF
--- a/frontend/lib/api-client.ts
+++ b/frontend/lib/api-client.ts
@@ -5,16 +5,22 @@ export const BASE_URL = 'https://fastapi-backend-825512055944.asia-northeast1.ru
 // 注意: Cloud RunのCORSが本番では無効のため、ブラウザからのloginリクエストは通らない
 // そのためJSON APIでログインしてトークンをキャッシュする方式を取る
 let cachedToken: string | null = null;
+let loggedOut = false;
 
 export function setToken(token: string) {
   cachedToken = token;
+  loggedOut = false;
 }
 
 export function clearToken() {
   cachedToken = null;
+  loggedOut = true;
 }
 
 async function getToken(): Promise<string> {
+  if (loggedOut) {
+    throw new Error('Not authenticated');
+  }
   if (cachedToken) return cachedToken;
 
   const res = await fetch(`${BASE_URL}/auth/login`, {


### PR DESCRIPTION
## Summary
- ログアウト後にテストアカウントで自動再ログインされ、ログイン画面遷移が無効化されていた問題を修正
- `api-client.ts` に `loggedOut` フラグを追加し、`clearToken()` 後は `getToken()` で自動ログインしないようにした

## Test plan
- [ ] マイページ → ログアウトボタン → 確認ダイアログ「OK」→ ログイン画面に遷移すること
- [ ] ログイン画面でテストアカウント情報を入力してログインできること
- [ ] ログアウト後にブラウザバックしてもタブ画面でAPI呼び出しが再認証されないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)