### PR TITLE
feat: ScheduleList/Templateにcategory, memo, 出発地フィールドを追加

### DIFF
--- a/backend/alembic/versions/c3d4e5f6a7b8_add_category_memo_departure_fields.py
+++ b/backend/alembic/versions/c3d4e5f6a7b8_add_category_memo_departure_fields.py
@@ -1,0 +1,93 @@
+"""add category, memo, departure fields to schedule_lists and templates
+
+Revision ID: c3d4e5f6a7b8
+Revises: b2c3d4e5f6a7
+Create Date: 2026-03-20 12:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "c3d4e5f6a7b8"
+down_revision: Union[str, None] = "b2c3d4e5f6a7"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # 1. Rename template_categories -> categories
+    op.rename_table("template_categories", "categories")
+
+    # 2. Update seed data: delete old, insert new
+    op.execute("DELETE FROM categories")
+    op.execute("INSERT INTO categories (name) VALUES ('休日'), ('旅行'), ('仕事'), ('出張')")
+
+    # 3. Rename templates.template_category_id -> category_id
+    # Drop old FK first, then rename column, then add new FK
+    op.drop_constraint("templates_template_category_id_fkey", "templates", type_="foreignkey")
+    op.alter_column("templates", "template_category_id", new_column_name="category_id")
+    op.create_foreign_key(
+        "templates_category_id_fkey", "templates", "categories", ["category_id"], ["id"], ondelete="SET NULL"
+    )
+
+    # 4. Add new columns to templates
+    op.add_column("templates", sa.Column("memo", sa.String(length=500), nullable=True))
+    op.add_column("templates", sa.Column("departure_name", sa.String(length=255), nullable=True))
+    op.add_column("templates", sa.Column("departure_lat", sa.Numeric(precision=9, scale=6), nullable=True))
+    op.add_column("templates", sa.Column("departure_lng", sa.Numeric(precision=9, scale=6), nullable=True))
+
+    # 5. Add new columns to schedule_lists
+    op.add_column("schedule_lists", sa.Column("category_id", sa.BigInteger(), nullable=True))
+    op.add_column("schedule_lists", sa.Column("memo", sa.String(length=500), nullable=True))
+    op.add_column("schedule_lists", sa.Column("departure_name", sa.String(length=255), nullable=True))
+    op.add_column("schedule_lists", sa.Column("departure_lat", sa.Numeric(precision=9, scale=6), nullable=True))
+    op.add_column("schedule_lists", sa.Column("departure_lng", sa.Numeric(precision=9, scale=6), nullable=True))
+    op.create_foreign_key(
+        "schedule_lists_category_id_fkey",
+        "schedule_lists",
+        "categories",
+        ["category_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+
+
+def downgrade() -> None:
+    # 1. schedule_lists: drop FK and new columns
+    op.drop_constraint("schedule_lists_category_id_fkey", "schedule_lists", type_="foreignkey")
+    op.drop_column("schedule_lists", "departure_lng")
+    op.drop_column("schedule_lists", "departure_lat")
+    op.drop_column("schedule_lists", "departure_name")
+    op.drop_column("schedule_lists", "memo")
+    op.drop_column("schedule_lists", "category_id")
+
+    # 2. templates: drop new columns
+    op.drop_column("templates", "departure_lng")
+    op.drop_column("templates", "departure_lat")
+    op.drop_column("templates", "departure_name")
+    op.drop_column("templates", "memo")
+
+    # 3. templates: drop FK, rename column back
+    op.drop_constraint("templates_category_id_fkey", "templates", type_="foreignkey")
+    op.alter_column("templates", "category_id", new_column_name="template_category_id")
+
+    # 4. Rename table back
+    op.rename_table("categories", "template_categories")
+
+    # 5. Recreate FK pointing at restored table name
+    op.create_foreign_key(
+        "templates_template_category_id_fkey",
+        "templates",
+        "template_categories",
+        ["template_category_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+
+    # 6. Restore seed data
+    op.execute("DELETE FROM template_categories")
+    op.execute("INSERT INTO template_categories (name) VALUES ('仕事の日'), ('在宅勤務'), ('休日')")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -5,7 +5,7 @@ from app.models.schedule import Schedule
 from app.models.schedule_list import PackingItem, ScheduleList
 from app.models.schedule_route import ScheduleRoute
 from app.models.tag import Tag
-from app.models.template import Template, TemplateCategory, TemplateSchedule
+from app.models.template import Category, Template, TemplateSchedule
 from app.models.user import NotificationSettings, User, UserSettings
 
 __all__ = [
@@ -19,7 +19,7 @@ __all__ = [
     "ScheduleRoute",
     "Tag",
     "Template",
-    "TemplateCategory",
+    "Category",
     "TemplateSchedule",
     "User",
     "UserSettings",

--- a/backend/app/models/schedule_list.py
+++ b/backend/app/models/schedule_list.py
@@ -1,15 +1,17 @@
 from __future__ import annotations
 
 import datetime as dt
+from decimal import Decimal
 from typing import TYPE_CHECKING
 
-from sqlalchemy import Boolean, Date, DateTime, ForeignKey, Integer, String, func
+from sqlalchemy import Boolean, Date, DateTime, ForeignKey, Integer, Numeric, String, func
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.models.base import Base, BigInt
 
 if TYPE_CHECKING:
     from app.models.schedule import Schedule
+    from app.models.template import Category
     from app.models.user import User
 
 
@@ -20,12 +22,20 @@ class ScheduleList(Base):
     user_id: Mapped[int] = mapped_column(BigInt, ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
     name: Mapped[str] = mapped_column(String(100), nullable=False)
     date: Mapped[dt.date] = mapped_column(Date, nullable=False)
+    category_id: Mapped[int | None] = mapped_column(
+        BigInt, ForeignKey("categories.id", ondelete="SET NULL"), nullable=True
+    )
+    memo: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    departure_name: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    departure_lat: Mapped[Decimal | None] = mapped_column(Numeric(9, 6), nullable=True)
+    departure_lng: Mapped[Decimal | None] = mapped_column(Numeric(9, 6), nullable=True)
     created_at: Mapped[dt.datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
     updated_at: Mapped[dt.datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
     )
 
     user: Mapped[User] = relationship(back_populates="schedule_lists")
+    category: Mapped[Category | None] = relationship(back_populates="schedule_lists")
     schedules: Mapped[list[Schedule]] = relationship(back_populates="schedule_list")
     packing_items: Mapped[list[PackingItem]] = relationship(
         back_populates="schedule_list", cascade="all, delete-orphan"

--- a/backend/app/models/template.py
+++ b/backend/app/models/template.py
@@ -11,16 +11,18 @@ from app.models.base import Base, BigInt
 from app.models.tag import Tag, template_schedule_tags
 
 if TYPE_CHECKING:
+    from app.models.schedule_list import ScheduleList
     from app.models.user import User
 
 
-class TemplateCategory(Base):
-    __tablename__ = "template_categories"
+class Category(Base):
+    __tablename__ = "categories"
 
     id: Mapped[int] = mapped_column(BigInt, primary_key=True, autoincrement=True)
     name: Mapped[str] = mapped_column(String(50), unique=True, nullable=False)
 
     templates: Mapped[list[Template]] = relationship(back_populates="category")
+    schedule_lists: Mapped[list[ScheduleList]] = relationship(back_populates="category")
 
 
 class Template(Base):
@@ -29,16 +31,20 @@ class Template(Base):
     id: Mapped[int] = mapped_column(BigInt, primary_key=True, autoincrement=True)
     user_id: Mapped[int] = mapped_column(BigInt, ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
     name: Mapped[str] = mapped_column(String(100), nullable=False)
-    template_category_id: Mapped[int | None] = mapped_column(
-        BigInt, ForeignKey("template_categories.id", ondelete="SET NULL"), nullable=True
+    category_id: Mapped[int | None] = mapped_column(
+        BigInt, ForeignKey("categories.id", ondelete="SET NULL"), nullable=True
     )
+    memo: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    departure_name: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    departure_lat: Mapped[Decimal | None] = mapped_column(Numeric(9, 6), nullable=True)
+    departure_lng: Mapped[Decimal | None] = mapped_column(Numeric(9, 6), nullable=True)
     created_at: Mapped[dt.datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
     updated_at: Mapped[dt.datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
     )
 
     user: Mapped[User] = relationship(back_populates="templates")
-    category: Mapped[TemplateCategory | None] = relationship(back_populates="templates")
+    category: Mapped[Category | None] = relationship(back_populates="templates")
     schedules: Mapped[list[TemplateSchedule]] = relationship(
         back_populates="template", cascade="all, delete-orphan", lazy="selectin"
     )

--- a/backend/app/schemas/schedule_lists.py
+++ b/backend/app/schemas/schedule_lists.py
@@ -1,6 +1,14 @@
 import datetime as dt
+from decimal import Decimal
 
 from pydantic import BaseModel
+
+
+class CategoryResponse(BaseModel):
+    id: int
+    name: str
+
+    model_config = {"from_attributes": True}
 
 
 class PackingItemResponse(BaseModel):
@@ -36,6 +44,11 @@ class ScheduleListResponse(BaseModel):
     id: int
     name: str
     date: dt.date
+    category: CategoryResponse | None
+    memo: str | None
+    departure_name: str | None
+    departure_lat: Decimal | None
+    departure_lng: Decimal | None
     schedules: list[ScheduleSummary]
     packing_items: list[PackingItemResponse]
     created_at: dt.datetime
@@ -47,9 +60,19 @@ class ScheduleListResponse(BaseModel):
 class ScheduleListCreate(BaseModel):
     name: str
     date: dt.date
+    category_id: int | None = None
+    memo: str | None = None
+    departure_name: str | None = None
+    departure_lat: Decimal | None = None
+    departure_lng: Decimal | None = None
     packing_items: list[PackingItemCreate] = []
 
 
 class ScheduleListUpdate(BaseModel):
     name: str | None = None
     date: dt.date | None = None
+    category_id: int | None = None
+    memo: str | None = None
+    departure_name: str | None = None
+    departure_lat: Decimal | None = None
+    departure_lng: Decimal | None = None

--- a/backend/app/schemas/templates.py
+++ b/backend/app/schemas/templates.py
@@ -3,14 +3,8 @@ from decimal import Decimal
 
 from pydantic import BaseModel
 
+from app.schemas.schedule_lists import CategoryResponse
 from app.schemas.tags import TagResponse
-
-
-class TemplateCategoryResponse(BaseModel):
-    id: int
-    name: str
-
-    model_config = {"from_attributes": True}
 
 
 class TemplateScheduleResponse(BaseModel):
@@ -33,7 +27,11 @@ class TemplateScheduleResponse(BaseModel):
 class TemplateResponse(BaseModel):
     id: int
     name: str
-    category: TemplateCategoryResponse | None
+    category: CategoryResponse | None
+    memo: str | None
+    departure_name: str | None
+    departure_lat: Decimal | None
+    departure_lng: Decimal | None
     schedules: list[TemplateScheduleResponse]
     created_at: dt.datetime
     updated_at: dt.datetime
@@ -58,12 +56,20 @@ class TemplateScheduleCreate(BaseModel):
 class TemplateCreate(BaseModel):
     name: str
     category_id: int | None = None
+    memo: str | None = None
+    departure_name: str | None = None
+    departure_lat: Decimal | None = None
+    departure_lng: Decimal | None = None
     schedules: list[TemplateScheduleCreate] = []
 
 
 class TemplateUpdate(BaseModel):
     name: str | None = None
     category_id: int | None = None
+    memo: str | None = None
+    departure_name: str | None = None
+    departure_lat: Decimal | None = None
+    departure_lng: Decimal | None = None
     schedules: list[TemplateScheduleCreate] | None = None
 
 

--- a/backend/app/services/schedule_lists_service.py
+++ b/backend/app/services/schedule_lists_service.py
@@ -17,7 +17,11 @@ from app.schemas.schedule_lists import (
 async def _get_owned_list(db: AsyncSession, user_id: int, list_id: int) -> ScheduleList:
     result = await db.execute(
         select(ScheduleList)
-        .options(selectinload(ScheduleList.schedules), selectinload(ScheduleList.packing_items))
+        .options(
+            selectinload(ScheduleList.category),
+            selectinload(ScheduleList.schedules),
+            selectinload(ScheduleList.packing_items),
+        )
         .where(ScheduleList.id == list_id, ScheduleList.user_id == user_id)
     )
     sl = result.scalar_one_or_none()
@@ -34,7 +38,11 @@ async def list_schedule_lists(
 ) -> list[ScheduleList]:
     stmt = (
         select(ScheduleList)
-        .options(selectinload(ScheduleList.schedules), selectinload(ScheduleList.packing_items))
+        .options(
+            selectinload(ScheduleList.category),
+            selectinload(ScheduleList.schedules),
+            selectinload(ScheduleList.packing_items),
+        )
         .where(ScheduleList.user_id == user_id)
         .order_by(ScheduleList.date)
     )
@@ -47,7 +55,16 @@ async def list_schedule_lists(
 
 
 async def create_schedule_list(db: AsyncSession, user_id: int, data: ScheduleListCreate) -> ScheduleList:
-    sl = ScheduleList(user_id=user_id, name=data.name, date=data.date)
+    sl = ScheduleList(
+        user_id=user_id,
+        name=data.name,
+        date=data.date,
+        category_id=data.category_id,
+        memo=data.memo,
+        departure_name=data.departure_name,
+        departure_lat=data.departure_lat,
+        departure_lng=data.departure_lng,
+    )
     db.add(sl)
     await db.flush()
 
@@ -69,6 +86,7 @@ async def update_schedule_list(db: AsyncSession, user_id: int, list_id: int, dat
     for key, value in update_data.items():
         setattr(sl, key, value)
     await db.commit()
+    db.expire(sl)
     return await _get_owned_list(db, user_id, list_id)
 
 

--- a/backend/app/services/templates_service.py
+++ b/backend/app/services/templates_service.py
@@ -70,7 +70,11 @@ async def create_template(db: AsyncSession, user_id: int, data: TemplateCreate) 
     template = Template(
         user_id=user_id,
         name=data.name,
-        template_category_id=data.category_id,
+        category_id=data.category_id,
+        memo=data.memo,
+        departure_name=data.departure_name,
+        departure_lat=data.departure_lat,
+        departure_lng=data.departure_lng,
     )
     db.add(template)
     await db.flush()
@@ -92,7 +96,7 @@ async def update_template(db: AsyncSession, user_id: int, template_id: int, data
     schedules_data = update_data.pop("schedules", None)
 
     if "category_id" in update_data:
-        template.template_category_id = update_data.pop("category_id")
+        template.category_id = update_data.pop("category_id")
 
     for key, value in update_data.items():
         setattr(template, key, value)

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -11,7 +11,7 @@ from app.database import get_db
 from app.main import app
 from app.models.base import Base
 from app.models.tag import Tag
-from app.models.template import TemplateCategory
+from app.models.template import Category
 
 # テスト用 PostgreSQL（環境変数 or docker-compose のデフォルト）
 TEST_DATABASE_URL = os.environ.get(
@@ -34,8 +34,8 @@ async def setup_db():
     async with session_factory() as session:
         for name in ["仕事", "会食", "デート", "運動"]:
             session.add(Tag(name=name))
-        for name in ["仕事の日", "在宅勤務", "休日"]:
-            session.add(TemplateCategory(name=name))
+        for name in ["休日", "旅行", "仕事", "出張"]:
+            session.add(Category(name=name))
         await session.commit()
 
     # FastAPI の依存関係を上書き

--- a/backend/tests/test_api_schedule_lists.py
+++ b/backend/tests/test_api_schedule_lists.py
@@ -7,6 +7,11 @@ from tests.conftest import auth_headers
 SL_DATA = {
     "name": "出社の日",
     "date": "2026-03-10",
+    "category_id": 3,
+    "memo": "お店の予約をする！",
+    "departure_name": "自宅",
+    "departure_lat": 35.6584,
+    "departure_lng": 139.7015,
     "packing_items": [
         {"name": "折りたたみ傘", "sort_order": 1},
         {"name": "名刺", "sort_order": 2},
@@ -27,8 +32,29 @@ class TestCreateScheduleList:
         data = response.json()
         assert data["name"] == "出社の日"
         assert data["date"] == "2026-03-10"
+        assert data["category"]["id"] == 3
+        assert data["category"]["name"] == "仕事"
+        assert data["memo"] == "お店の予約をする！"
+        assert data["departure_name"] == "自宅"
+        assert float(data["departure_lat"]) == pytest.approx(35.6584, abs=1e-4)
+        assert float(data["departure_lng"]) == pytest.approx(139.7015, abs=1e-4)
         assert len(data["packing_items"]) == 2
         assert data["packing_items"][0]["name"] == "折りたたみ傘"
+
+    async def test_create_without_optional_fields(self, client):
+        headers = await auth_headers(client)
+        response = await client.post(
+            "/api/v1/schedule-lists",
+            headers=headers,
+            json={"name": "シンプルな予定", "date": "2026-03-11"},
+        )
+        assert response.status_code == 201
+        data = response.json()
+        assert data["category"] is None
+        assert data["memo"] is None
+        assert data["departure_name"] is None
+        assert data["departure_lat"] is None
+        assert data["departure_lng"] is None
 
     async def test_create_without_token(self, client):
         response = await client.post("/api/v1/schedule-lists", json=SL_DATA)
@@ -70,6 +96,21 @@ class TestUpdateScheduleList:
         response = await client.put(f"/api/v1/schedule-lists/{list_id}", headers=headers, json={"name": "在宅の日"})
         assert response.status_code == 200
         assert response.json()["name"] == "在宅の日"
+
+    async def test_update_new_fields(self, client):
+        headers = await auth_headers(client)
+        create_resp = await _create_list(client, headers)
+        list_id = create_resp.json()["id"]
+        response = await client.put(
+            f"/api/v1/schedule-lists/{list_id}",
+            headers=headers,
+            json={"memo": "更新メモ", "category_id": 1, "departure_name": "東京駅"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["memo"] == "更新メモ"
+        assert data["category"]["name"] == "休日"
+        assert data["departure_name"] == "東京駅"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_api_templates.py
+++ b/backend/tests/test_api_templates.py
@@ -6,7 +6,11 @@ from tests.conftest import auth_headers
 
 TEMPLATE_DATA = {
     "name": "仕事の日ルーティン",
-    "category_id": 1,
+    "category_id": 3,
+    "memo": "スーツ着用の日",
+    "departure_name": "自宅",
+    "departure_lat": 35.6584,
+    "departure_lng": 139.7015,
     "schedules": [
         {
             "title": "朝の準備",
@@ -40,7 +44,11 @@ class TestCreateTemplate:
         assert response.status_code == 201
         data = response.json()
         assert data["name"] == "仕事の日ルーティン"
-        assert data["category"]["name"] == "仕事の日"
+        assert data["category"]["name"] == "仕事"
+        assert data["memo"] == "スーツ着用の日"
+        assert data["departure_name"] == "自宅"
+        assert float(data["departure_lat"]) == pytest.approx(35.6584, abs=1e-4)
+        assert float(data["departure_lng"]) == pytest.approx(139.7015, abs=1e-4)
         assert len(data["schedules"]) == 2
         assert data["schedules"][0]["title"] == "朝の準備"
         assert len(data["schedules"][0]["tags"]) == 1
@@ -94,6 +102,20 @@ class TestUpdateTemplate:
         assert response.json()["name"] == "更新ルーティン"
         # Schedules should remain
         assert len(response.json()["schedules"]) == 2
+
+    async def test_update_new_fields(self, client):
+        headers = await auth_headers(client)
+        create_resp = await _create_template(client, headers)
+        template_id = create_resp.json()["id"]
+        response = await client.put(
+            f"/api/v1/templates/{template_id}",
+            headers=headers,
+            json={"memo": "更新メモ", "departure_name": "東京駅"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["memo"] == "更新メモ"
+        assert data["departure_name"] == "東京駅"
 
     async def test_update_replace_schedules(self, client):
         headers = await auth_headers(client)


### PR DESCRIPTION
## Summary
- ScheduleListとTemplateに予定の種類(category_id)、一言メモ(memo)、出発地(departure_name/lat/lng)を追加
- `template_categories`テーブルを`categories`にリネームし、ScheduleListとTemplateの両方から参照する共通カテゴリテーブルに変更
- カテゴリのシードデータを「休日・旅行・仕事・出張」に更新
- Alembicマイグレーション追加

## Test plan
- [x] `ruff check . && ruff format --check .` 通過
- [x] `pytest tests/test_api_schedule_lists.py -v` 全テスト通過（新フィールドのCRUDテスト含む）
- [x] `pytest tests/test_api_templates.py -v` 全テスト通過（新フィールドのCRUDテスト含む）
- [x] `pytest tests/ -v` 全172テスト通過
- [x] Alembicマイグレーション適用確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)