### PR TITLE
feat: カテゴリ一覧取得エンドポイントを追加

### DIFF
--- a/backend/app/api/categories.py
+++ b/backend/app/api/categories.py
@@ -1,0 +1,18 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import get_db
+from app.dependencies.auth import get_current_user
+from app.models.user import User
+from app.schemas.schedule_lists import CategoryResponse
+from app.services import categories_service
+
+router = APIRouter(prefix="/categories", tags=["categories"])
+
+
+@router.get("", response_model=list[CategoryResponse])
+async def list_categories(
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    return await categories_service.list_categories(db)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -3,6 +3,7 @@ from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.api.auth import router as auth_router
+from app.api.categories import router as categories_router
 from app.api.healthz import router as healthz_router
 from app.api.notifications import router as notifications_router
 from app.api.routes import router as routes_router
@@ -48,6 +49,7 @@ app.add_exception_handler(Exception, generic_error_handler)
 app.include_router(healthz_router)
 app.include_router(auth_router, prefix="/api/v1")
 app.include_router(users_router, prefix="/api/v1")
+app.include_router(categories_router, prefix="/api/v1")
 app.include_router(tags_router, prefix="/api/v1")
 app.include_router(schedules_router, prefix="/api/v1")
 app.include_router(schedule_lists_router, prefix="/api/v1")

--- a/backend/app/services/categories_service.py
+++ b/backend/app/services/categories_service.py
@@ -1,0 +1,9 @@
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.template import Category
+
+
+async def list_categories(db: AsyncSession) -> list[Category]:
+    result = await db.execute(select(Category).order_by(Category.id))
+    return list(result.scalars().all())

--- a/backend/tests/test_api_categories.py
+++ b/backend/tests/test_api_categories.py
@@ -1,0 +1,23 @@
+"""categories API エンドポイントのテスト."""
+
+import pytest
+
+from tests.conftest import auth_headers
+
+
+@pytest.mark.asyncio
+class TestListCategories:
+    async def test_list_success(self, client):
+        headers = await auth_headers(client)
+        response = await client.get("/api/v1/categories", headers=headers)
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 4
+        assert data[0]["name"] == "休日"
+        assert data[1]["name"] == "旅行"
+        assert data[2]["name"] == "仕事"
+        assert data[3]["name"] == "出張"
+
+    async def test_list_without_token(self, client):
+        response = await client.get("/api/v1/categories")
+        assert response.status_code == 403


### PR DESCRIPTION
## Summary
- `GET /api/v1/categories` エンドポイントを追加（認証必須）
- スケジュールリスト作成画面でカテゴリ選択肢（休日・旅行・仕事・出張）を取得するために使用

## Test plan
- [x] `ruff check . && ruff format --check .` 通過
- [x] `pytest tests/test_api_categories.py -v` 全テスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)