### PR TITLE
feat: transit_lines マスターテーブル作成 & データインポート

### DIFF
--- a/backend/alembic/versions/d4e5f6a7b8c9_create_transit_lines_table.py
+++ b/backend/alembic/versions/d4e5f6a7b8c9_create_transit_lines_table.py
@@ -1,0 +1,38 @@
+"""create transit_lines table
+
+Revision ID: d4e5f6a7b8c9
+Revises: c3d4e5f6a7b8
+Create Date: 2026-03-22 22:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "d4e5f6a7b8c9"
+down_revision: Union[str, None] = "c3d4e5f6a7b8"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "transit_lines",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("line_key", sa.String(100), nullable=False),
+        sa.Column("name_ja", sa.String(100), nullable=False),
+        sa.Column("name_en", sa.String(200), nullable=True),
+        sa.Column("color", sa.String(10), nullable=False),
+        sa.Column("operator", sa.String(100), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("line_key"),
+    )
+    op.create_index("ix_transit_lines_name_ja", "transit_lines", ["name_ja"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_transit_lines_name_ja", table_name="transit_lines")
+    op.drop_table("transit_lines")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -6,6 +6,7 @@ from app.models.schedule_list import PackingItem, ScheduleList
 from app.models.schedule_route import ScheduleRoute
 from app.models.tag import Tag
 from app.models.template import Category, Template, TemplateSchedule
+from app.models.transit_line import TransitLine
 from app.models.user import NotificationSettings, User, UserSettings
 
 __all__ = [
@@ -21,6 +22,7 @@ __all__ = [
     "Template",
     "Category",
     "TemplateSchedule",
+    "TransitLine",
     "User",
     "UserSettings",
 ]

--- a/backend/app/models/transit_line.py
+++ b/backend/app/models/transit_line.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from sqlalchemy import String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base, BigInt
+
+
+class TransitLine(Base):
+    __tablename__ = "transit_lines"
+
+    id: Mapped[int] = mapped_column(BigInt, primary_key=True, autoincrement=True)
+    line_key: Mapped[str] = mapped_column(String(100), nullable=False, unique=True)
+    name_ja: Mapped[str] = mapped_column(String(100), nullable=False, index=True)
+    name_en: Mapped[str | None] = mapped_column(String(200), nullable=True)
+    color: Mapped[str] = mapped_column(String(10), nullable=False)
+    operator: Mapped[str | None] = mapped_column(String(100), nullable=True)

--- a/backend/scripts/import_railways.py
+++ b/backend/scripts/import_railways.py
@@ -1,0 +1,61 @@
+"""railways.json から transit_lines テーブルにデータをインポートするスクリプト.
+
+データソース: https://github.com/nagix/mini-tokyo-3d/tree/master/data
+
+Usage:
+    cd backend
+    python scripts/import_railways.py
+"""
+
+import asyncio
+import json
+import urllib.request
+
+from sqlalchemy import select
+
+from app.database import async_session, engine
+from app.models.transit_line import TransitLine
+
+RAILWAYS_URL = "https://raw.githubusercontent.com/nagix/mini-tokyo-3d/master/data/railways.json"
+
+
+async def import_railways() -> None:
+    print(f"Fetching railways.json from {RAILWAYS_URL} ...")
+    with urllib.request.urlopen(RAILWAYS_URL) as resp:
+        data = json.loads(resp.read().decode())
+
+    print(f"Found {len(data)} railways.")
+
+    async with async_session() as session:
+        existing = await session.execute(select(TransitLine.line_key))
+        existing_keys = {row[0] for row in existing.all()}
+
+        inserted = 0
+        skipped = 0
+        for r in data:
+            line_key = r["id"]
+            if line_key in existing_keys:
+                skipped += 1
+                continue
+
+            operator = line_key.split(".")[0] if "." in line_key else None
+            title = r.get("title", {})
+
+            line = TransitLine(
+                line_key=line_key,
+                name_ja=title.get("ja", ""),
+                name_en=title.get("en"),
+                color=r.get("color", "#888888"),
+                operator=operator,
+            )
+            session.add(line)
+            inserted += 1
+
+        await session.commit()
+        print(f"Done: {inserted} inserted, {skipped} skipped (already exist).")
+
+    await engine.dispose()
+
+
+if __name__ == "__main__":
+    asyncio.run(import_railways())


### PR DESCRIPTION
## Summary
- `transit_lines` マスターテーブルを作成（路線色分け機能の基盤）
- [mini-tokyo-3d/railways.json](https://github.com/nagix/mini-tokyo-3d/tree/master/data) からのインポートスクリプトを追加
- 本番DBにマイグレーション&インポート済み（172路線）

## テーブル定義
| カラム | 型 | 説明 | 例 |
|---|---|---|---|
| id | BigInt PK | 自動採番 | 1 |
| line_key | String (unique) | railways.json の ID | `JR-East.Yamanote` |
| name_ja | String (indexed) | 日本語路線名 | `山手線` |
| name_en | String (nullable) | 英語路線名 | `Yamanote Line` |
| color | String | HEXカラーコード | `#80C342` |
| operator | String (nullable) | 事業者名 | `JR-East` |

## Test plan
- [x] 本番DBにマイグレーション実行済み
- [x] 172路線のインポート完了確認済み
- [ ] CIが通ること

Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)