### PR TITLE
feat: 路線マスター参照API・ルート検索紐付け・路線色動的表示 (#92, #93, #94)

### DIFF
--- a/backend/app/api/transit_lines.py
+++ b/backend/app/api/transit_lines.py
@@ -1,0 +1,31 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import get_db
+from app.dependencies.auth import get_current_user
+from app.exceptions import AppError
+from app.models.user import User
+from app.schemas.transit_lines import TransitLineResponse
+from app.services import transit_lines_service
+
+router = APIRouter(prefix="/transit-lines", tags=["transit-lines"])
+
+
+@router.get("", response_model=list[TransitLineResponse])
+async def list_transit_lines(
+    _current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    return await transit_lines_service.list_transit_lines(db)
+
+
+@router.get("/{line_id}", response_model=TransitLineResponse)
+async def get_transit_line(
+    line_id: int,
+    _current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    line = await transit_lines_service.get_transit_line(db, line_id)
+    if line is None:
+        raise AppError("NOT_FOUND", "Transit line not found", 404)
+    return line

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -13,6 +13,7 @@ from app.api.schedules import router as schedules_router
 from app.api.suggestions import router as suggestions_router
 from app.api.tags import router as tags_router
 from app.api.templates import router as templates_router
+from app.api.transit_lines import router as transit_lines_router
 from app.api.transit_status import router as transit_status_router
 from app.api.users import router as users_router
 from app.api.weather import router as weather_router
@@ -59,5 +60,6 @@ app.include_router(weather_router, prefix="/api/v1")
 app.include_router(routes_router, prefix="/api/v1")
 app.include_router(schedule_routes_router, prefix="/api/v1")
 app.include_router(suggestions_router, prefix="/api/v1")
+app.include_router(transit_lines_router, prefix="/api/v1")
 app.include_router(transit_status_router, prefix="/api/v1")
 app.include_router(notifications_router, prefix="/api/v1")

--- a/backend/app/schemas/routes.py
+++ b/backend/app/schemas/routes.py
@@ -54,6 +54,8 @@ class LegResponse(BaseModel):
     route_long_name: str | None = None
     agency_name: str | None = None
     headsign: str | None = None
+    transit_line_id: int | None = None
+    route_color: str | None = None
 
 
 class ItineraryResponse(BaseModel):

--- a/backend/app/schemas/transit_lines.py
+++ b/backend/app/schemas/transit_lines.py
@@ -1,0 +1,12 @@
+from pydantic import BaseModel
+
+
+class TransitLineResponse(BaseModel):
+    id: int
+    line_key: str
+    name_ja: str
+    name_en: str | None = None
+    color: str
+    operator: str | None = None
+
+    model_config = {"from_attributes": True}

--- a/backend/app/services/routes_service.py
+++ b/backend/app/services/routes_service.py
@@ -11,7 +11,16 @@ from app.models.schedule import Schedule
 from app.models.schedule_route import ScheduleRoute
 from app.models.user import UserSettings
 from app.schemas.routes import DepartureTimeRequest, RouteSearchRequest, ScheduleRouteCreate
-from app.services import otp2_client
+from app.services import otp2_client, transit_line_cache
+
+
+async def _enrich_itineraries(db: AsyncSession, itineraries: list[dict]) -> None:
+    """Enrich each leg with transit_line_id and route_color from cache."""
+    for itinerary in itineraries:
+        for leg in itinerary.get("legs", []):
+            match = await transit_line_cache.lookup(db, leg.get("route_long_name"))
+            leg["transit_line_id"] = match["transit_line_id"]
+            leg["route_color"] = match["route_color"]
 
 
 async def _get_user_settings(db: AsyncSession, user_id: int) -> UserSettings:
@@ -52,6 +61,8 @@ async def search_routes(db: AsyncSession, user_id: int, data: RouteSearchRequest
         arrival_time=arrival_time_str,
     )
 
+    await _enrich_itineraries(db, itineraries)
+
     return {"itineraries": itineraries}
 
 
@@ -69,6 +80,8 @@ async def calculate_departure_time(db: AsyncSession, user_id: int, data: Departu
         travel_mode=data.travel_mode,
         arrival_time=data.arrival_time.isoformat(),
     )
+
+    await _enrich_itineraries(db, itineraries)
 
     from datetime import datetime
 

--- a/backend/app/services/transit_line_cache.py
+++ b/backend/app/services/transit_line_cache.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import logging
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.transit_line import TransitLine
+
+logger = logging.getLogger(__name__)
+
+# Module-level cache: name_ja -> {transit_line_id, route_color}
+_cache: dict[str, dict[str, int | str | None]] = {}
+_loaded: bool = False
+
+
+async def _load_cache(db: AsyncSession) -> None:
+    global _cache, _loaded
+    result = await db.execute(select(TransitLine))
+    lines = result.scalars().all()
+    _cache = {
+        line.name_ja: {"transit_line_id": line.id, "route_color": line.color}
+        for line in lines
+    }
+    _loaded = True
+    logger.info("Transit line cache loaded: %d entries", len(_cache))
+
+
+_NO_MATCH: dict[str, int | str | None] = {"transit_line_id": None, "route_color": None}
+
+
+async def lookup(db: AsyncSession, name_ja: str | None) -> dict[str, int | str | None]:
+    """Return {"transit_line_id": int|None, "route_color": str|None}."""
+    global _loaded
+    if not _loaded:
+        await _load_cache(db)
+    if name_ja is None:
+        return _NO_MATCH
+    return _cache.get(name_ja, _NO_MATCH)
+
+
+def invalidate() -> None:
+    """Reset cache so next lookup reloads from DB."""
+    global _cache, _loaded
+    _cache = {}
+    _loaded = False

--- a/backend/app/services/transit_line_cache.py
+++ b/backend/app/services/transit_line_cache.py
@@ -10,6 +10,8 @@ from app.models.transit_line import TransitLine
 logger = logging.getLogger(__name__)
 
 # Module-level cache: name_ja -> {transit_line_id, route_color}
+# NOTE: name_ja is not unique in DB, but OTP route_long_name matches name_ja
+# well enough for color lookup. If duplicates exist, the first match wins.
 _cache: dict[str, dict[str, int | str | None]] = {}
 _loaded: bool = False
 
@@ -18,10 +20,13 @@ async def _load_cache(db: AsyncSession) -> None:
     global _cache, _loaded
     result = await db.execute(select(TransitLine))
     lines = result.scalars().all()
-    _cache = {
-        line.name_ja: {"transit_line_id": line.id, "route_color": line.color}
-        for line in lines
-    }
+    _cache = {}
+    for line in lines:
+        # Keep first entry for duplicate name_ja (avoid silent overwrite)
+        if line.name_ja not in _cache:
+            _cache[line.name_ja] = {"transit_line_id": line.id, "route_color": line.color}
+        else:
+            logger.warning("Duplicate name_ja '%s' (id=%d), skipping", line.name_ja, line.id)
     _loaded = True
     logger.info("Transit line cache loaded: %d entries", len(_cache))
 

--- a/backend/app/services/transit_lines_service.py
+++ b/backend/app/services/transit_lines_service.py
@@ -1,0 +1,14 @@
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.transit_line import TransitLine
+
+
+async def list_transit_lines(db: AsyncSession) -> list[TransitLine]:
+    result = await db.execute(select(TransitLine).order_by(TransitLine.id))
+    return list(result.scalars().all())
+
+
+async def get_transit_line(db: AsyncSession, line_id: int) -> TransitLine | None:
+    result = await db.execute(select(TransitLine).where(TransitLine.id == line_id))
+    return result.scalar_one_or_none()

--- a/backend/scripts/import_railways.py
+++ b/backend/scripts/import_railways.py
@@ -8,9 +8,8 @@ Usage:
 """
 
 import asyncio
-import json
-import urllib.request
 
+import httpx
 from sqlalchemy import select
 
 from app.database import async_session, engine
@@ -21,8 +20,14 @@ RAILWAYS_URL = "https://raw.githubusercontent.com/nagix/mini-tokyo-3d/master/dat
 
 async def import_railways() -> None:
     print(f"Fetching railways.json from {RAILWAYS_URL} ...")
-    with urllib.request.urlopen(RAILWAYS_URL) as resp:
-        data = json.loads(resp.read().decode())
+    try:
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(RAILWAYS_URL, timeout=30)
+            resp.raise_for_status()
+            data = resp.json()
+    except httpx.HTTPError as e:
+        print(f"Error fetching railways.json: {e}")
+        return
 
     print(f"Found {len(data)} railways.")
 

--- a/frontend/api/routeApi.ts
+++ b/frontend/api/routeApi.ts
@@ -22,6 +22,8 @@ export interface LegResponse {
   route_long_name?: string;
   agency_name?: string;
   headsign?: string;
+  transit_line_id?: number;
+  route_color?: string;
 }
 
 export interface ItineraryResponse {

--- a/frontend/app/schedule/unit/detail.tsx
+++ b/frontend/app/schedule/unit/detail.tsx
@@ -172,7 +172,7 @@ export default function ScheduleDetailScreen() {
             mode === 'RAIL' || mode === 'SUBWAY' || mode === 'TRANSIT' || mode === 'BUS'
               ? leg.route_long_name || leg.route_short_name || leg.agency_name
               : undefined,
-          lineColor: C.accent,
+          lineColor: leg.route_color || C.accent,
           walk: mode === 'WALK' ? `${leg.duration_minutes}分` : undefined,
           past: false,
           iconName: modeIcon as any,

--- a/frontend/utils/timeline-helper.ts
+++ b/frontend/utils/timeline-helper.ts
@@ -116,7 +116,7 @@ export function buildTimelineItems(
           lineName: isTransit
             ? leg.route_long_name || leg.route_short_name || leg.agency_name
             : undefined,
-          lineColor: '#6E8F8A',
+          lineColor: leg.route_color || '#6E8F8A',
           walk: mode === 'WALK' ? `${leg.duration_minutes}分` : undefined,
           past: isPast(leg.departure_time),
           iconName: modeIcon,


### PR DESCRIPTION
- #91 (PR#95) transit_linesモデル・マイグレーション・インポートスクリプトをcherry-pick
- #92 GET /api/v1/transit-lines, GET /api/v1/transit-lines/{id} APIを追加
- #93 メモリキャッシュによるname_ja完全一致でルート検索結果にtransit_line_id/route_colorを付与
- #94 フロントエンドのハードコード色をAPI値に置換（フォールバック付き）

https://claude.ai/code/session_012mRGzccyaGzcdgUxv6DLq1