### PR TITLE
fix: マイグレーションのonupdate欠落修正とdocstring更新

### DIFF
--- a/backend/alembic/versions/f6a7b8c9d0e1_rebuild_suggestion_caches_per_user.py
+++ b/backend/alembic/versions/f6a7b8c9d0e1_rebuild_suggestion_caches_per_user.py
@@ -28,7 +28,13 @@ def upgrade() -> None:
         sa.Column("suggestion_text", sa.Text(), nullable=False),
         sa.Column("weather_summary_json", sa.JSON(), nullable=False),
         sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
-        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            onupdate=sa.func.now(),
+            nullable=False,
+        ),
         sa.PrimaryKeyConstraint("id"),
         sa.UniqueConstraint("user_id", "target_date"),
     )

--- a/backend/app/api/batch.py
+++ b/backend/app/api/batch.py
@@ -28,6 +28,6 @@ async def batch_weather(db=Depends(get_db)):  # noqa: ANN001
 
 @router.post("/suggestions")
 async def batch_suggestions(db=Depends(get_db)):  # noqa: ANN001
-    """全都道府県のLLM文言を一括生成してDBに保存する."""
+    """当日スケジュールを持つ全ユーザーのLLM文言を一括生成してDBに保存する."""
     result = await suggestion_batch_service.generate_all_suggestions(db)
     return result


### PR DESCRIPTION
## Summary
- `suggestion_caches` マイグレーション (`f6a7b8c9d0e1`) の `updated_at` カラムに `onupdate=sa.func.now()` が欠落していたため追加
- `batch_suggestions` エンドポイントのdocstringを「全都道府県」→「全ユーザー」に修正（PR #103 でユーザー単位に再設計済みのため）

## Test plan
- [ ] `alembic upgrade head` が正常に完了すること
- [ ] 既存テストが通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)